### PR TITLE
Patch restructure template components

### DIFF
--- a/.github/workflows/publish-dev-release.yml
+++ b/.github/workflows/publish-dev-release.yml
@@ -13,9 +13,13 @@ on:
         description: >-
           The custom version to be used for branch, tag, and release. Do not use an existing tag in the repo.
         required: true
+      name-prefix:
+        description: >-
+          The branch name prefix. Default: devrel_
+        required: false
       no-publish:
         description: >-
-          Skip the publication steps.
+          Boolean indicator to skip the publication steps.
         required: true
         default: 'false'
 jobs:
@@ -23,13 +27,16 @@ jobs:
     runs-on: ubuntu-latest
     name: main job
     steps:
+      - name: preparation
+        run: |
+          echo "name-prefix=${{ github.event.inputs['name-prefix'] && 'devrel_' || github.event.inputs['name-prefix'] }}" >> $GITHUB_ENV
       - name: create release branch
         id: create-branch
         uses: fortinet/github-action-version-branch@1.0.2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           base-branch: ${{ github.event.inputs['base-branch'] }}
-          name-prefix: devrel_
+          name-prefix: ${{ env['name-prefix'] }}
           custom-version: ${{ github.event.inputs['custom-version'] }}
       - name: checkout dev release branch
         uses: actions/checkout@v2

--- a/.github/workflows/publish-dev-release.yml
+++ b/.github/workflows/publish-dev-release.yml
@@ -13,6 +13,11 @@ on:
         description: >-
           The custom version to be used for branch, tag, and release. Do not use an existing tag in the repo.
         required: true
+      no-publish:
+        description: >-
+          Skip the publication steps.
+        required: true
+        default: 'false'
 jobs:
   main_job:
     runs-on: ubuntu-latest
@@ -62,10 +67,12 @@ jobs:
           echo "::set-output name=tag-commit::$(git rev-parse HEAD)"
       # prepare release assets
       - name: make dist
+        if: ${{ github.event.inputs['no-publish'] != 'true'  }}
         run: npm run make-dist
       # create a release
       - id: create-release
         name: create release
+        if: ${{ github.event.inputs['no-publish'] != 'true'  }}
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
@@ -77,6 +84,7 @@ jobs:
           commitish: ${{ steps['push-changes'].outputs['tag-commit'] }} # Use the output: `tag-commit` from a prev step
       - id: upload-release-asset
         name: upload release assets
+        if: ${{ github.event.inputs['no-publish'] != 'true'  }}
         uses: svenstaro/upload-release-action@2.2.0
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/templates/deploy_fortigate_autoscale.hybrid_licensing.json
+++ b/templates/deploy_fortigate_autoscale.hybrid_licensing.json
@@ -30,14 +30,6 @@
                 "description": "The number of FortiGate instances the BYOL VMSS should have at any time. For High Availability in BYOL-only and Hybrid use cases, ensure at least 2 FortiGates are in the group. For specific use cases, set to 0 for PAYG-only, and >= 2 for BYOL-only or hybrid licensing."
             }
         },
-        "FOSVersion": {
-            "defaultValue": "6.4.5",
-            "allowedValues": ["6.4.5"],
-            "type": "String",
-            "metadata": {
-                "description": "FortiOS version supported by FortiGate Autoscale for Azure."
-            }
-        },
         "FortiAnalyzerAutoscaleAdminPassword": {
             "type": "securestring",
             "metadata": {
@@ -57,7 +49,6 @@
             }
         },
         "FortiAnalyzerInstanceType": {
-            "defaultValue": "Standard_D2",
             "type": "String",
             "metadata": {
                 "description": "Size of the FortiAnalyzer VM."
@@ -83,6 +74,14 @@
             "type": "SecureString",
             "metadata": {
                 "description": "The secret key for the FortiGates instances to securely communicate with each other. Must contain numbers and letters and may contain special characters. Maximum length is 128."
+            }
+        },
+        "FosVersion": {
+            "defaultValue": "6.4.5",
+            "allowedValues": ["6.4.5"],
+            "type": "String",
+            "metadata": {
+                "description": "FortiOS version supported by FortiGate Autoscale for Azure."
             }
         },
         "FrontendIPDeploymentMethod": {
@@ -376,17 +375,23 @@
         "extLBInboundNatPoolSSHBYOL": "[concat(variables('vmssNameBYOL'), '-nat-pool-ssh')]",
         "extLBInboundNatPoolSSHPAYG": "[concat(variables('vmssNamePAYG'), '-nat-pool-ssh')]",
         "externalLoadBalancerName": "[concat(parameters('ResourceNamePrefix'), '-external-load-balancer')]",
-        "fgtvmImageBYOL": {
+        "vmImgReferenceFazBYOL": {
+            "publisher": "fortinet",
+            "offer": "fortinet-fortianalyzer",
+            "sku": "fortinet-fortianalyzer",
+            "version": "[parameters('FortiAnalyzerVersion')]"
+        },
+        "vmImgReferenceFgtBYOL": {
             "publisher": "fortinet",
             "offer": "fortinet_fortigate-vm_v5",
             "sku": "fortinet_fg-vm",
-            "version": "[parameters('fosversion')]"
+            "version": "[parameters('FosVersion')]"
         },
-        "fgtvmImagePAYG": {
+        "vmImgReferenceFgtPAYG": {
             "publisher": "fortinet",
             "offer": "fortinet_fortigate-vm_v5",
             "sku": "fortinet_fg-vm_payg_20190624",
-            "version": "[parameters('fosversion')]"
+            "version": "[parameters('FosVersion')]"
         },
         "funcAppIPResrictionPriority": 100,
         "funcAppIPResrictions": {
@@ -1536,9 +1541,6 @@
                     "FortiAnalyzerInstanceType": {
                         "value": "[parameters('FortiAnalyzerInstanceType')]"
                     },
-                    "FortiAnalyzerVersion": {
-                        "value": "[parameters('FortiAnalyzerVersion')]"
-                    },
                     "Location": {
                         "value": "[resourceGroup().location]"
                     },
@@ -1550,6 +1552,9 @@
                     },
                     "UniqueResourceNamePrefix": {
                         "value": "[variables('uniqueResourceNamePrefix')]"
+                    },
+                    "VmImgReferenceFaz": {
+                        "value": "[variables('vmImgReferenceFazBYOL')]"
                     }
                 }
             },
@@ -1750,11 +1755,11 @@
                     "ExternalLoadBalancerName": {
                         "value": "[variables('externalLoadBalancerName')]"
                     },
-                    "FgtVmImageBYOL": {
-                        "value": "[variables('fgtvmImageBYOL')]"
+                    "VmImageReferenceFgtBYOL": {
+                        "value": "[variables('vmImgReferenceFgtBYOL')]"
                     },
-                    "FgtVmImagePAYG": {
-                        "value": "[variables('fgtvmImagePAYG')]"
+                    "VmImageReferenceFgtPAYG": {
+                        "value": "[variables('vmImgReferenceFgtPAYG')]"
                     },
                     "FunctionAppName": {
                         "value": "[variables('functionAppName')]"

--- a/templates/deploy_fortigate_autoscale.hybrid_licensing.json
+++ b/templates/deploy_fortigate_autoscale.hybrid_licensing.json
@@ -1541,12 +1541,6 @@
                     "FortiAnalyzerInstanceType": {
                         "value": "[parameters('FortiAnalyzerInstanceType')]"
                     },
-                    "Location": {
-                        "value": "[resourceGroup().location]"
-                    },
-                    "ResourceGroupName": {
-                        "value": "[resourceGroup().name]"
-                    },
                     "SubnetId": {
                         "value": "[variables('subnet1Id')]"
                     },
@@ -1578,17 +1572,11 @@
                     "FunctionExtensionVersion": {
                         "value": "~3"
                     },
-                    "Location": {
-                        "value": "[resourceGroup().location]"
-                    },
                     "NodeJSRuntimeVersion": {
                         "value": "~12"
                     },
                     "PackageResURL": {
                         "value": "[parameters('PackageResURL')]"
-                    },
-                    "ResourceGroupName": {
-                        "value": "[resourceGroup().name]"
                     },
                     "ServicePlanTier": {
                         "value": "[parameters('ServicePlanTier')]"
@@ -1794,9 +1782,6 @@
                     "LoadBalancerBackendIPPoolNameSubnet4": {
                         "value": "[variables('loadBalancerBackendIPPoolNameSubnet4')]"
                     },
-                    "Location": {
-                        "value": "[variables('vNetResourceGroupName')]"
-                    },
                     "MaxBYOLInstanceCount": {
                         "value": "[parameters('MaxBYOLInstanceCount')]"
                     },
@@ -1811,9 +1796,6 @@
                     },
                     "PAYGInstanceCount": {
                         "value": "[parameters('PAYGInstanceCount')]"
-                    },
-                    "ResourceGroupName": {
-                        "value": "[variables('vNetResourceGroupName')]"
                     },
                     "ResourceNamePrefix": {
                         "value": "[parameters('ResourceNamePrefix')]"
@@ -1854,7 +1836,7 @@
                 }
             },
             "subscriptionId": "[subscription().subscriptionId]",
-            "resourceGroup": "[resourceGroup().name]"
+            "resourceGroup": "[variables('vNetResourceGroupName')]"
         }
     ],
     "outputs": {

--- a/templates/deploy_fortigate_autoscale.hybrid_licensing.json
+++ b/templates/deploy_fortigate_autoscale.hybrid_licensing.json
@@ -63,8 +63,8 @@
             }
         },
         "FortiAnalyzerVersion": {
-            "defaultValue": "6.4.4",
-            "allowedValues": ["6.4.4", "6.2.5"],
+            "defaultValue": "6.4.5",
+            "allowedValues": ["6.4.5", "6.2.5"],
             "type": "String",
             "metadata": {
                 "description": "The FortiAnalyzer version supported by Fortinet FortiGate Auto Scaling."

--- a/templates/deploy_fortigate_autoscale.hybrid_licensing.json
+++ b/templates/deploy_fortigate_autoscale.hybrid_licensing.json
@@ -1619,6 +1619,9 @@
                     "FortiAnalyzerIntegrationOptions": {
                         "value": "[parameters('FortiAnalyzerIntegrationOptions')]"
                     },
+                    "FortiAnalyzerPublicIp": {
+                        "value": "[if(variables('enableFortiAnalyzer'), reference('FortiAnalyzerIntegrationResources').outputs.fazPublicIp.value, '')]"
+                    },
                     "FortiGatePSKSecret": {
                         "value": "[parameters('FortiGatePSKSecret')]"
                     },

--- a/templates/deploy_fortigate_autoscale.hybrid_licensing.json
+++ b/templates/deploy_fortigate_autoscale.hybrid_licensing.json
@@ -354,191 +354,17 @@
         "autoscaleEndpointByolLicense": "[concat(variables('funcappURL'), '/api/byol-license')]",
         "autoscaleEndpointFazHandler": "[concat(variables('funcappURL'), '/api/faz-auth-handler')]",
         "autoscaleEndpointFgtAsHandler": "[concat(variables('funcappURL'), '/api/fgt-as-handler')]",
-        "autoscaleSettingsNameBYOL": "[concat(parameters('ResourceNamePrefix'), '-autoscalesettings-byol')]",
-        "autoscaleSettingsNamePAYG": "[concat(parameters('ResourceNamePrefix'), '-autoscalesettings-payg')]",
-        "autoscaleSettingsPresets": {
-            "byolonly": {
-                "byol": [
-                    {
-                        "metricTrigger": {
-                            "metricName": "Percentage CPU",
-                            "metricNamespace": "",
-                            "metricResourceUri": "[concat('/subscriptions/',subscription().subscriptionId, '/resourceGroups/',  variables('vNetResourceGroupName'), '/providers/Microsoft.Compute/virtualMachineScaleSets/', variables('vmssNameBYOL'))]",
-                            "timeGrain": "PT1M",
-                            "statistic": "Average",
-                            "timeWindow": "PT5M",
-                            "timeAggregation": "Average",
-                            "operator": "GreaterThan",
-                            "threshold": "[parameters('ScaleOutThreshold')]"
-                        },
-                        "scaleAction": {
-                            "direction": "Increase",
-                            "type": "ChangeCount",
-                            "value": "1",
-                            "cooldown": "PT1M"
-                        }
-                    },
-                    {
-                        "metricTrigger": {
-                            "metricName": "Percentage CPU",
-                            "metricNamespace": "",
-                            "metricResourceUri": "[concat('/subscriptions/',subscription().subscriptionId, '/resourceGroups/',  variables('vNetResourceGroupName'), '/providers/Microsoft.Compute/virtualMachineScaleSets/', variables('vmssNameBYOL'))]",
-                            "timeGrain": "PT1M",
-                            "statistic": "Average",
-                            "timeWindow": "PT5M",
-                            "timeAggregation": "Average",
-                            "operator": "LessThan",
-                            "threshold": "[parameters('ScaleInThreshold')]"
-                        },
-                        "scaleAction": {
-                            "direction": "Decrease",
-                            "type": "ChangeCount",
-                            "value": "1",
-                            "cooldown": "PT1M"
-                        }
-                    }
-                ],
-                "payg": []
-            },
-            "hybrid": {
-                "byol": [],
-                "payg": [
-                    {
-                        "metricTrigger": {
-                            "metricName": "Percentage CPU",
-                            "metricNamespace": "",
-                            "metricResourceUri": "[concat('/subscriptions/',subscription().subscriptionId, '/resourceGroups/',  variables('vNetResourceGroupName'), '/providers/Microsoft.Compute/virtualMachineScaleSets/', variables('vmssNameBYOL'))]",
-                            "timeGrain": "PT1M",
-                            "statistic": "Average",
-                            "timeWindow": "PT5M",
-                            "timeAggregation": "Average",
-                            "operator": "GreaterThan",
-                            "threshold": "[parameters('ScaleOutThreshold')]"
-                        },
-                        "scaleAction": {
-                            "direction": "Increase",
-                            "type": "ChangeCount",
-                            "value": "1",
-                            "cooldown": "PT1M"
-                        }
-                    },
-                    {
-                        "metricTrigger": {
-                            "metricName": "Percentage CPU",
-                            "metricNamespace": "",
-                            "metricResourceUri": "[concat('/subscriptions/',subscription().subscriptionId, '/resourceGroups/',  variables('vNetResourceGroupName'), '/providers/Microsoft.Compute/virtualMachineScaleSets/', variables('vmssNamePAYG'))]",
-                            "timeGrain": "PT1M",
-                            "statistic": "Average",
-                            "timeWindow": "PT5M",
-                            "timeAggregation": "Average",
-                            "operator": "GreaterThan",
-                            "threshold": "[parameters('ScaleOutThreshold')]"
-                        },
-                        "scaleAction": {
-                            "direction": "Increase",
-                            "type": "ChangeCount",
-                            "value": "1",
-                            "cooldown": "PT1M"
-                        }
-                    },
-                    {
-                        "metricTrigger": {
-                            "metricName": "Percentage CPU",
-                            "metricNamespace": "",
-                            "metricResourceUri": "[concat('/subscriptions/',subscription().subscriptionId, '/resourceGroups/',  variables('vNetResourceGroupName'), '/providers/Microsoft.Compute/virtualMachineScaleSets/', variables('vmssNameBYOL'))]",
-                            "timeGrain": "PT1M",
-                            "statistic": "Average",
-                            "timeWindow": "PT5M",
-                            "timeAggregation": "Average",
-                            "operator": "LessThan",
-                            "threshold": "[parameters('ScaleInThreshold')]"
-                        },
-                        "scaleAction": {
-                            "direction": "Decrease",
-                            "type": "ChangeCount",
-                            "value": "1",
-                            "cooldown": "PT1M"
-                        }
-                    },
-                    {
-                        "metricTrigger": {
-                            "metricName": "Percentage CPU",
-                            "metricNamespace": "",
-                            "metricResourceUri": "[concat('/subscriptions/',subscription().subscriptionId, '/resourceGroups/',  variables('vNetResourceGroupName'), '/providers/Microsoft.Compute/virtualMachineScaleSets/', variables('vmssNamePAYG'))]",
-                            "timeGrain": "PT1M",
-                            "statistic": "Average",
-                            "timeWindow": "PT5M",
-                            "timeAggregation": "Average",
-                            "operator": "LessThan",
-                            "threshold": "[parameters('ScaleInThreshold')]"
-                        },
-                        "scaleAction": {
-                            "direction": "Decrease",
-                            "type": "ChangeCount",
-                            "value": "1",
-                            "cooldown": "PT1M"
-                        }
-                    }
-                ]
-            },
-            "paygonly": {
-                "byol": [],
-                "payg": [
-                    {
-                        "metricTrigger": {
-                            "metricName": "Percentage CPU",
-                            "metricNamespace": "",
-                            "metricResourceUri": "[concat('/subscriptions/',subscription().subscriptionId, '/resourceGroups/',  variables('vNetResourceGroupName'), '/providers/Microsoft.Compute/virtualMachineScaleSets/', variables('vmssNamePAYG'))]",
-                            "timeGrain": "PT1M",
-                            "statistic": "Average",
-                            "timeWindow": "PT5M",
-                            "timeAggregation": "Average",
-                            "operator": "GreaterThan",
-                            "threshold": "[parameters('ScaleOutThreshold')]"
-                        },
-                        "scaleAction": {
-                            "direction": "Increase",
-                            "type": "ChangeCount",
-                            "value": "1",
-                            "cooldown": "PT1M"
-                        }
-                    },
-                    {
-                        "metricTrigger": {
-                            "metricName": "Percentage CPU",
-                            "metricNamespace": "",
-                            "metricResourceUri": "[concat('/subscriptions/',subscription().subscriptionId, '/resourceGroups/',  variables('vNetResourceGroupName'), '/providers/Microsoft.Compute/virtualMachineScaleSets/', variables('vmssNamePAYG'))]",
-                            "timeGrain": "PT1M",
-                            "statistic": "Average",
-                            "timeWindow": "PT5M",
-                            "timeAggregation": "Average",
-                            "operator": "LessThan",
-                            "threshold": "[parameters('ScaleInThreshold')]"
-                        },
-                        "scaleAction": {
-                            "direction": "Decrease",
-                            "type": "ChangeCount",
-                            "value": "1",
-                            "cooldown": "PT1M"
-                        }
-                    }
-                ]
-            }
-        },
-        "cmdDeleteAutoscaleAll": "[concat(variables('cmdDeleteVNetRelatedComponents'), variables('cmdDeleteAutoscaleComponents'))]",
-        "cmdDeleteAutoscaleComponents": "[concat('az account set -s ', subscription().subscriptionId, ';', 'az group delete -y -n ', variables('resourceGroupName'), ';')]",
-        "cmdDeleteAutoscaleSettings": "[if(variables('ifCreateVNetInSameRSG'), '', concat('az monitor autoscale delete -g ', variables('vNetResourceGroupName'), ' -n ', variables('autoscaleSettingsNameBYOL'), ';', 'az monitor autoscale delete -g ', variables('vNetResourceGroupName'), ' -n ', variables('autoscaleSettingsNamePAYG'), ';'))]",
-        "cmdDeleteLBS": "[concat('az network lb delete -g ', variables('vNetResourceGroupName'),' -n ', variables('externalLoadBalancerName'), ';', 'az network lb delete -g ', variables('vNetResourceGroupName'),' -n ', variables('internalLoadBalancerName'), ';')]",
-        "cmdDeleteNetworkSecurityGroup": "[if(variables('ifCreateVNet'), concat('az network nsg delete -g ', variables('vNetResourceGroupName'),' -n ', variables('networkSecurityGroupName'), ';'), '')]",
-        "cmdDeletePublicIP": "[if(and(not(variables('ifCreateVNetInSameRSG')), variables('ifCreateNewPublicIP')), concat('az network public-ip delete -g ', variables('vNetResourceGroupName'), ' -n ', variables('publicIPAddressName'), ';'), '')]",
-        "cmdDeleteRouteTable1": "[if(variables('ifCreateVNet'), concat('az network route-table delete -g ', variables('vNetResourceGroupName'),' -n ', variables('intRouteTable1Name'), ';'), '')]",
-        "cmdDeleteRouteTable2": "[if(variables('ifCreateVNet'), concat('az network route-table delete -g ', variables('vNetResourceGroupName'),' -n ', variables('intRouteTable2Name'), ';'), '')]",
-        "cmdDeleteRouteTable3": "[if(variables('ifCreateVNet'), concat('az network route-table delete -g ', variables('vNetResourceGroupName'),' -n ', variables('intRouteTable3Name'), ';'), '')]",
+        "cmdDeleteAutoscaleAll": "[concat(variables('cmdDeleteVNetRelatedComponents'), variables('cmdDeleteAutoscaleResourceGroup'))]",
+        "cmdDeleteAutoscaleResourceGroup": "[concat('az account set -s ', subscription().subscriptionId, ';', 'az group delete -y -n ', resourceGroup().name, ';')]",
+        "cmdDeleteLBS": "[concat('az account set -s ', subscription().subscriptionId, ';', 'az network lb delete -g ', variables('vNetResourceGroupName'),' -n ', variables('externalLoadBalancerName'), ';', 'az network lb delete -g ', variables('vNetResourceGroupName'),' -n ', variables('internalLoadBalancerName'), ';')]",
+        "cmdDeleteNetworkSecurityGroup": "[if(variables('ifCreateVNet'), concat('az account set -s ', subscription().subscriptionId, ';', 'az network nsg delete -g ', variables('vNetResourceGroupName'),' -n ', variables('networkSecurityGroupName'), ';'), '')]",
+        "cmdDeletePublicIP": "[if(and(not(variables('ifCreateVNetInSameRSG')), variables('ifCreateNewPublicIP')), concat('az account set -s ', subscription().subscriptionId, ';', 'az network public-ip delete -g ', variables('vNetResourceGroupName'), ' -n ', variables('publicIPAddressName'), ';'), '')]",
+        "cmdDeleteRouteTable1": "[if(variables('ifCreateVNet'), concat('az account set -s ', subscription().subscriptionId, ';', 'az network route-table delete -g ', variables('vNetResourceGroupName'),' -n ', variables('intRouteTable1Name'), ';'), '')]",
+        "cmdDeleteRouteTable2": "[if(variables('ifCreateVNet'), concat('az account set -s ', subscription().subscriptionId, ';', 'az network route-table delete -g ', variables('vNetResourceGroupName'),' -n ', variables('intRouteTable2Name'), ';'), '')]",
+        "cmdDeleteRouteTable3": "[if(variables('ifCreateVNet'), concat('az account set -s ', subscription().subscriptionId, ';', 'az network route-table delete -g ', variables('vNetResourceGroupName'),' -n ', variables('intRouteTable3Name'), ';'), '')]",
         "cmdDeleteRouteTableAll": "[concat(variables('cmdDeleteRouteTable1'), variables('cmdDeleteRouteTable2'), variables('cmdDeleteRouteTable3'))]",
-        "cmdDeleteVMSS": "[concat('az vmss delete -g ', variables('vNetResourceGroupName'),' -n ', variables('vmssNameBYOL'), ';', 'az vmss delete -g ', variables('vNetResourceGroupName'),' -n ', variables('vmssNamePAYG'), ';')]",
-        "cmdDeleteVNet": "[if(variables('ifCreateVNet'), concat('az network vnet delete -g ', variables('vNetResourceGroupName'),' -n ', variables('vNetName'), ';'), '')]",
-        "cmdDeleteVNetRelatedComponents": "[if(and(not(variables('ifCreateVNetInSameRSG')), variables('ifCreateVNet')), concat('az account set -s ', subscription().subscriptionId, ';', variables('cmdDeleteVMSS'), variables('cmdDeleteLBS'), variables('cmdDeleteVNet'), variables('cmdDeleteNetworkSecurityGroup'), variables('cmdDeletePublicIP'), variables('cmdDeleteRouteTableAll'), variables('cmdDeleteAutoscaleSettings')), '')]",
-        "cmdVNetCleanUp": "[concat('az account set -s ', subscription().subscriptionId, ';', variables('cmdDeleteAutoscaleSettings'))]",
+        "cmdDeleteVNet": "[if(variables('ifCreateVNet'), concat('az account set -s ', subscription().subscriptionId, ';', 'az network vnet delete -g ', variables('vNetResourceGroupName'),' -n ', variables('vNetName'), ';'), '')]",
+        "cmdDeleteVNetRelatedComponents": "[if(and(not(variables('ifCreateVNetInSameRSG')), variables('ifCreateVNet')), concat('az account set -s ', subscription().subscriptionId, ';', variables('cmdDeleteLBS'), variables('cmdDeleteVNet'), variables('cmdDeleteNetworkSecurityGroup'), variables('cmdDeletePublicIP'), variables('cmdDeleteRouteTableAll')), '')]",
         "databaseAccountName": "[concat(toLower(variables('uniqueResourceNamePrefix')),'dba001')]",
         "databaseName": "FortiGateAutoscale",
         "databaseSharedThroughput": "[add(add(variables('databaseSharedThroughputBase'), if(variables('enableHybridLicensing'), 200, 0)), if(variables('enableFortiAnalyzer'), 100, 0))]",
@@ -655,24 +481,19 @@
         "networkSecurityGroupName": "[if(and(variables('ifCreateVNet'), empty(parameters('NetworkSecurityGroupName'))), concat(parameters('ResourceNamePrefix'), '-network-security-group'), if(empty(parameters('NetworkSecurityGroupName')), 'not-applicable', parameters('NetworkSecurityGroupName')))]",
         "publicIPAddressId": "[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', variables('vNetResourceGroupName'), '/providers/Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]",
         "publicIPAddressName": "[if(and(variables('ifCreateNewPublicIP'), empty(parameters('FrontendIPName'))), concat(variables('vNetName'), '-ext-lb-public-ip'), parameters('FrontendIPName'))]",
-        "resourceGroupName": "[resourceGroup().name]",
-        "storageAccountId": "[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', variables('resourceGroupName'), '/providers/Microsoft.Storage/storageAccounts/', variables('storageAccountName'))]",
+        "storageAccountId": "[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Storage/storageAccounts/', variables('storageAccountName'))]",
         "storageAccountName": "[concat(toLower(variables('uniqueResourceNamePrefix')),'sta001')]",
-        "subnet1IPConfigName": "[concat(parameters('ResourceNamePrefix'), '-ip-config-subnet1')]",
         "subnet1Id": "[concat(variables('vnetID'), '/subnets/', variables('subnet1Name'))]",
         "subnet1Name": "[if(and(variables('ifCreateVNet'), empty(parameters('Subnet1Name'))), concat(variables('vNetName'), '-subnet1'), parameters('Subnet1Name'))]",
         "subnet1Prefix": "[parameters('Subnet1AddressRange')]",
-        "subnet2IPConfigName": "[concat(parameters('ResourceNamePrefix'), '-ip-config-subnet2')]",
         "subnet2Id": "[concat(variables('vnetID'),'/Subnets/', variables('subnet2Name'))]",
         "subnet2LoadBalancerIP": "[concat(substring(variables('subnet2Prefix'), 0, lastIndexOf(variables('subnet2Prefix'), '.')),'.', parameters('LoadBalancerIP'))]",
         "subnet2Name": "[if(and(variables('ifCreateVNet'), empty(parameters('Subnet1Name'))), concat(variables('vNetName'), '-subnet2'), parameters('Subnet2Name'))]",
         "subnet2Prefix": "[parameters('Subnet2AddressRange')]",
-        "subnet3IPConfigName": "[concat(parameters('ResourceNamePrefix'), '-ip-config-subnet3')]",
         "subnet3Id": "[concat(variables('vnetID'),'/Subnets/', variables('subnet3Name'))]",
         "subnet3LoadBalancerIP": "[concat(substring(variables('subnet3Prefix'), 0, lastIndexOf(variables('subnet3Prefix'), '.')),'.', parameters('LoadBalancerIP'))]",
         "subnet3Name": "[if(and(variables('ifCreateVNet'), empty(parameters('Subnet1Name'))), concat(variables('vNetName'), '-subnet3'), parameters('Subnet3Name'))]",
         "subnet3Prefix": "[parameters('Subnet3AddressRange')]",
-        "subnet4IPConfigName": "[concat(parameters('ResourceNamePrefix'), '-ip-config-subnet4')]",
         "subnet4Id": "[concat(variables('vnetID'),'/Subnets/', variables('subnet4Name'))]",
         "subnet4LoadBalancerIP": "[concat(substring(variables('subnet4Prefix'), 0, lastIndexOf(variables('subnet4Prefix'), '.')),'.', parameters('LoadBalancerIP'))]",
         "subnet4Name": "[if(and(variables('ifCreateVNet'), empty(parameters('Subnet1Name'))), concat(variables('vNetName'), '-subnet4'), parameters('Subnet4Name'))]",
@@ -1671,7 +1492,7 @@
                 }
             },
             "subscriptionId": "[subscription().subscriptionId]",
-            "resourceGroup": "[variables('resourceGroupName')]"
+            "resourceGroup": "[resourceGroup().name]"
         },
         {
             "type": "Microsoft.Resources/deployments",
@@ -1716,7 +1537,7 @@
                 }
             },
             "subscriptionId": "[subscription().subscriptionId]",
-            "resourceGroup": "[variables('resourceGroupName')]"
+            "resourceGroup": "[resourceGroup().name]"
         },
         {
             "type": "Microsoft.Resources/deployments",
@@ -1760,7 +1581,7 @@
                 }
             },
             "subscriptionId": "[subscription().subscriptionId]",
-            "resourceGroup": "[variables('resourceGroupName')]"
+            "resourceGroup": "[resourceGroup().name]"
         },
         {
             "type": "Microsoft.Resources/deployments",
@@ -1794,7 +1615,7 @@
                 }
             },
             "subscriptionId": "[subscription().subscriptionId]",
-            "resourceGroup": "[variables('resourceGroupName')]"
+            "resourceGroup": "[resourceGroup().name]"
         },
         {
             "type": "Microsoft.Resources/deployments",
@@ -1868,7 +1689,7 @@
                                         },
                                         {
                                             "name": "AUTOSCALE_DB_PRIMARY_KEY",
-                                            "value": "[listKeys(resourceId(subscription().subscriptionId, variables('resourceGroupName'), 'Microsoft.DocumentDb/databaseAccounts', variables('databaseAccountName')), '2016-03-31').primaryMasterKey]"
+                                            "value": "[listKeys(resourceId(subscription().subscriptionId, resourceGroup().name, 'Microsoft.DocumentDb/databaseAccounts', variables('databaseAccountName')), '2016-03-31').primaryMasterKey]"
                                         },
                                         {
                                             "name": "AUTOSCALE_KEY_VAULT_NAME",
@@ -1876,7 +1697,7 @@
                                         },
                                         {
                                             "name": "AZURE_STORAGE_ACCESS_KEY",
-                                            "value": "[listKeys(resourceId(subscription().subscriptionId, variables('resourceGroupName'), 'Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2019-04-01').keys[0].value]"
+                                            "value": "[listKeys(resourceId(subscription().subscriptionId, resourceGroup().name, 'Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2019-04-01').keys[0].value]"
                                         },
                                         {
                                             "name": "AZURE_STORAGE_ACCOUNT",
@@ -2106,7 +1927,7 @@
                 }
             },
             "subscriptionId": "[subscription().subscriptionId]",
-            "resourceGroup": "[variables('resourceGroupName')]"
+            "resourceGroup": "[resourceGroup().name]"
         },
         {
             "type": "Microsoft.Resources/deployments",
@@ -2115,454 +1936,214 @@
             "dependsOn": ["CreateFunctionApp"],
             "properties": {
                 "mode": "Incremental",
-                "template": {
-                    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-                    "contentVersion": "1.0.0.0",
-                    "parameters": {},
-                    "variables": {},
-                    "resources": [
-                        {
-                            "type": "Microsoft.Compute/virtualMachineScaleSets",
-                            "apiVersion": "2019-07-01",
-                            "name": "[variables('vmssNameBYOL')]",
-                            "location": "[variables('location')]",
-                            "plan": {
-                                "name": "[variables('fgtvmImageBYOL').sku]",
-                                "publisher": "[variables('fgtvmImageBYOL').publisher]",
-                                "product": "[variables('fgtvmImageBYOL').offer]"
-                            },
-                            "sku": {
-                                "name": "[parameters('InstanceType')]",
-                                "tier": "Standard",
-                                "capacity": 0
-                            },
-                            "properties": {
-                                "overprovision": false,
-                                "upgradePolicy": {
-                                    "mode": "Manual"
-                                },
-                                "virtualMachineProfile": {
-                                    "storageProfile": {
-                                        "osDisk": {
-                                            "createOption": "FromImage",
-                                            "caching": "ReadWrite"
-                                        },
-                                        "dataDisks": [
-                                            {
-                                                "diskSizeGB": 30,
-                                                "lun": 1,
-                                                "createOption": "Empty"
-                                            }
-                                        ],
-                                        "imageReference": "[variables('fgtvmImageBYOL')]"
-                                    },
-                                    "diagnosticsProfile": {
-                                        "bootDiagnostics": {
-                                            "enabled": true,
-                                            "storageUri": "[concat('https://', variables('storageAccountName'), '.blob.core.windows.net')]"
-                                        }
-                                    },
-                                    "osProfile": {
-                                        "computerNamePrefix": "[variables('vmssNameBYOL')]",
-                                        "adminUsername": "[parameters('adminUsername')]",
-                                        "customData": "[base64(concat('{\"license-url\": \"', variables('autoscaleEndpointByolLicense'), '?code=', reference('CreateFunctionApp').outputs.functionKeyList.value['byol-license'], '\",\"config-url\": \"', variables('autoscaleEndpointFgtAsHandler'), '?code=', reference('CreateFunctionApp').outputs.functionKeyList.value['fgt-as-handler'], '\"}\n'))]",
-                                        "adminPassword": "[parameters('adminPassword')]"
-                                    },
-                                    "networkProfile": {
-                                        "networkInterfaceConfigurations": [
-                                            {
-                                                "name": "[concat(variables('vmssNameBYOL'),'-nic-subnet1')]",
-                                                "properties": {
-                                                    "primary": true,
-                                                    "enableIPForwarding": true,
-                                                    "ipConfigurations": [
-                                                        {
-                                                            "name": "[variables('subnet1IPConfigName')]",
-                                                            "properties": {
-                                                                "Subnet": {
-                                                                    "id": "[resourceId(subscription().subscriptionId, variables('vNetResourceGroupName'), 'Microsoft.Network/virtualNetworks/subnets', variables('vNetName'), variables('subnet1Name'))]"
-                                                                },
-                                                                "loadBalancerBackendAddressPools": [
-                                                                    {
-                                                                        "id": "[resourceId(subscription().subscriptionId, variables('vNetResourceGroupName'), 'Microsoft.Network/loadBalancers/backendAddressPools', variables('externalLoadBalancerName'), variables('loadBalancerBackendIPPoolNameSubnet1'))]"
-                                                                    }
-                                                                ],
-                                                                "loadBalancerInboundNatPools": [
-                                                                    {
-                                                                        "id": "[resourceId(subscription().subscriptionId, variables('vNetResourceGroupName'), 'Microsoft.Network/loadBalancers/inboundNatPools', variables('externalLoadBalancerName'), variables('extLBInboundNatPoolSSHBYOL'))]"
-                                                                    },
-                                                                    {
-                                                                        "id": "[resourceId(subscription().subscriptionId, variables('vNetResourceGroupName'), 'Microsoft.Network/loadBalancers/inboundNatPools', variables('externalLoadBalancerName'), variables('extLBInboundNatPoolHTTPSBYOL'))]"
-                                                                    }
-                                                                ]
-                                                            }
-                                                        }
-                                                    ]
-                                                }
-                                            },
-                                            {
-                                                "name": "[concat(variables('vmssNameBYOL'),'-nic-subnet2')]",
-                                                "properties": {
-                                                    "primary": false,
-                                                    "enableIPForwarding": true,
-                                                    "ipConfigurations": [
-                                                        {
-                                                            "name": "[variables('subnet2IPConfigName')]",
-                                                            "properties": {
-                                                                "Subnet": {
-                                                                    "id": "[resourceId(subscription().subscriptionId, variables('vNetResourceGroupName'), 'Microsoft.Network/virtualNetworks/subnets', variables('vNetName'), variables('subnet2Name'))]"
-                                                                },
-                                                                "loadBalancerBackendAddressPools": [
-                                                                    {
-                                                                        "id": "[resourceId(subscription().subscriptionId, variables('vNetResourceGroupName'), 'Microsoft.Network/loadBalancers/backendAddressPools', variables('internalLoadBalancerName'), variables('loadBalancerBackendIPPoolNameSubnet2'))]"
-                                                                    }
-                                                                ]
-                                                            }
-                                                        }
-                                                    ]
-                                                }
-                                            },
-                                            {
-                                                "name": "[concat(variables('vmssNameBYOL'),'-nic-subnet3')]",
-                                                "properties": {
-                                                    "primary": false,
-                                                    "enableIPForwarding": true,
-                                                    "ipConfigurations": [
-                                                        {
-                                                            "name": "[variables('subnet3IPConfigName')]",
-                                                            "properties": {
-                                                                "Subnet": {
-                                                                    "id": "[resourceId(subscription().subscriptionId, variables('vNetResourceGroupName'), 'Microsoft.Network/virtualNetworks/subnets', variables('vNetName'), variables('subnet3Name'))]"
-                                                                },
-                                                                "loadBalancerBackendAddressPools": [
-                                                                    {
-                                                                        "id": "[resourceId(subscription().subscriptionId, variables('vNetResourceGroupName'), 'Microsoft.Network/loadBalancers/backendAddressPools', variables('internalLoadBalancerName'), variables('loadBalancerBackendIPPoolNameSubnet3'))]"
-                                                                    }
-                                                                ]
-                                                            }
-                                                        }
-                                                    ]
-                                                }
-                                            },
-                                            {
-                                                "name": "[concat(variables('vmssNameBYOL'),'-nic-subnet4')]",
-                                                "properties": {
-                                                    "primary": false,
-                                                    "enableIPForwarding": true,
-                                                    "ipConfigurations": [
-                                                        {
-                                                            "name": "[variables('subnet4IPConfigName')]",
-                                                            "properties": {
-                                                                "Subnet": {
-                                                                    "id": "[resourceId(subscription().subscriptionId, variables('vNetResourceGroupName'), 'Microsoft.Network/virtualNetworks/subnets', variables('vNetName'), variables('subnet4Name'))]"
-                                                                },
-                                                                "loadBalancerBackendAddressPools": [
-                                                                    {
-                                                                        "id": "[resourceId(subscription().subscriptionId, variables('vNetResourceGroupName'), 'Microsoft.Network/loadBalancers/backendAddressPools', variables('internalLoadBalancerName'), variables('loadBalancerBackendIPPoolNameSubnet4'))]"
-                                                                    }
-                                                                ]
-                                                            }
-                                                        }
-                                                    ]
-                                                }
-                                            }
-                                        ]
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "type": "Microsoft.Compute/virtualMachineScaleSets",
-                            "name": "[variables('vmssNamePAYG')]",
-                            "location": "[variables('location')]",
-                            "apiVersion": "2019-07-01",
-                            "plan": {
-                                "name": "[variables('fgtvmImagePAYG').sku]",
-                                "publisher": "[variables('fgtvmImagePAYG').publisher]",
-                                "product": "[variables('fgtvmImagePAYG').offer]"
-                            },
-                            "sku": {
-                                "name": "[parameters('InstanceType')]",
-                                "tier": "Standard",
-                                "capacity": 0
-                            },
-                            "properties": {
-                                "overprovision": false,
-                                "upgradePolicy": {
-                                    "mode": "Manual"
-                                },
-                                "virtualMachineProfile": {
-                                    "storageProfile": {
-                                        "osDisk": {
-                                            "createOption": "FromImage",
-                                            "caching": "ReadWrite"
-                                        },
-                                        "dataDisks": [
-                                            {
-                                                "diskSizeGB": 30,
-                                                "lun": 1,
-                                                "createOption": "Empty"
-                                            }
-                                        ],
-                                        "imageReference": "[variables('fgtvmImagePAYG')]"
-                                    },
-                                    "diagnosticsProfile": {
-                                        "bootDiagnostics": {
-                                            "enabled": true,
-                                            "storageUri": "[concat('https://', variables('storageAccountName'), '.blob.core.windows.net')]"
-                                        }
-                                    },
-                                    "priority": "Low",
-                                    "evictionPolicy": "delete",
-                                    "osProfile": {
-                                        "computerNamePrefix": "[variables('vmssNamePAYG')]",
-                                        "customData": "[base64(concat('{\"config-url\": \"', variables('autoscaleEndpointFgtAsHandler'), '?code=', reference('CreateFunctionApp').outputs.functionKeyList.value['fgt-as-handler'], '\"}\n'))]",
-                                        "adminUsername": "[parameters('adminUsername')]",
-                                        "adminPassword": "[parameters('adminPassword')]"
-                                    },
-                                    "networkProfile": {
-                                        "networkInterfaceConfigurations": [
-                                            {
-                                                "name": "[concat(variables('vmssNamePAYG'),'-nic-subnet1')]",
-                                                "properties": {
-                                                    "primary": true,
-                                                    "enableIPForwarding": true,
-                                                    "ipConfigurations": [
-                                                        {
-                                                            "name": "[variables('subnet1IPConfigName')]",
-                                                            "properties": {
-                                                                "Subnet": {
-                                                                    "id": "[resourceId(subscription().subscriptionId, variables('vNetResourceGroupName'), 'Microsoft.Network/virtualNetworks/subnets', variables('vNetName'), variables('subnet1Name'))]"
-                                                                },
-                                                                "loadBalancerBackendAddressPools": [
-                                                                    {
-                                                                        "id": "[resourceId(subscription().subscriptionId, variables('vNetResourceGroupName'), 'Microsoft.Network/loadBalancers/backendAddressPools', variables('externalLoadBalancerName'), variables('loadBalancerBackendIPPoolNameSubnet1'))]"
-                                                                    }
-                                                                ],
-                                                                "loadBalancerInboundNatPools": [
-                                                                    {
-                                                                        "id": "[resourceId(subscription().subscriptionId, variables('vNetResourceGroupName'), 'Microsoft.Network/loadBalancers/inboundNatPools', variables('externalLoadBalancerName'), variables('extLBInboundNatPoolSSHPAYG'))]"
-                                                                    },
-                                                                    {
-                                                                        "id": "[resourceId(subscription().subscriptionId, variables('vNetResourceGroupName'), 'Microsoft.Network/loadBalancers/inboundNatPools', variables('externalLoadBalancerName'), variables('extLBInboundNatPoolHTTPSPAYG'))]"
-                                                                    }
-                                                                ]
-                                                            }
-                                                        }
-                                                    ]
-                                                }
-                                            },
-                                            {
-                                                "name": "[concat(variables('vmssNamePAYG'),'-nic-subnet2')]",
-                                                "properties": {
-                                                    "primary": false,
-                                                    "enableIPForwarding": true,
-                                                    "ipConfigurations": [
-                                                        {
-                                                            "name": "[variables('subnet2IPConfigName')]",
-                                                            "properties": {
-                                                                "Subnet": {
-                                                                    "id": "[resourceId(subscription().subscriptionId, variables('vNetResourceGroupName'), 'Microsoft.Network/virtualNetworks/subnets', variables('vNetName'), variables('subnet2Name'))]"
-                                                                },
-                                                                "loadBalancerBackendAddressPools": [
-                                                                    {
-                                                                        "id": "[resourceId(subscription().subscriptionId, variables('vNetResourceGroupName'), 'Microsoft.Network/loadBalancers/backendAddressPools', variables('internalLoadBalancerName'), variables('loadBalancerBackendIPPoolNameSubnet2'))]"
-                                                                    }
-                                                                ]
-                                                            }
-                                                        }
-                                                    ]
-                                                }
-                                            },
-                                            {
-                                                "name": "[concat(variables('vmssNamePAYG'),'-nic-subnet3')]",
-                                                "properties": {
-                                                    "primary": false,
-                                                    "enableIPForwarding": true,
-                                                    "ipConfigurations": [
-                                                        {
-                                                            "name": "[variables('subnet3IPConfigName')]",
-                                                            "properties": {
-                                                                "Subnet": {
-                                                                    "id": "[resourceId(subscription().subscriptionId, variables('vNetResourceGroupName'), 'Microsoft.Network/virtualNetworks/subnets', variables('vNetName'), variables('subnet3Name'))]"
-                                                                },
-                                                                "loadBalancerBackendAddressPools": [
-                                                                    {
-                                                                        "id": "[resourceId(subscription().subscriptionId, variables('vNetResourceGroupName'), 'Microsoft.Network/loadBalancers/backendAddressPools', variables('internalLoadBalancerName'), variables('loadBalancerBackendIPPoolNameSubnet3'))]"
-                                                                    }
-                                                                ]
-                                                            }
-                                                        }
-                                                    ]
-                                                }
-                                            },
-                                            {
-                                                "name": "[concat(variables('vmssNamePAYG'),'-nic-subnet4')]",
-                                                "properties": {
-                                                    "primary": false,
-                                                    "enableIPForwarding": true,
-                                                    "ipConfigurations": [
-                                                        {
-                                                            "name": "[variables('subnet4IPConfigName')]",
-                                                            "properties": {
-                                                                "Subnet": {
-                                                                    "id": "[resourceId(subscription().subscriptionId, variables('vNetResourceGroupName'), 'Microsoft.Network/virtualNetworks/subnets', variables('vNetName'), variables('subnet4Name'))]"
-                                                                },
-                                                                "loadBalancerBackendAddressPools": [
-                                                                    {
-                                                                        "id": "[resourceId(subscription().subscriptionId, variables('vNetResourceGroupName'), 'Microsoft.Network/loadBalancers/backendAddressPools', variables('internalLoadBalancerName'), variables('loadBalancerBackendIPPoolNameSubnet4'))]"
-                                                                    }
-                                                                ]
-                                                            }
-                                                        }
-                                                    ]
-                                                }
-                                            }
-                                        ]
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "dependsOn": ["[variables('vmssNameBYOL')]"],
-                            "type": "Microsoft.Insights/autoscaleSettings",
-                            "apiVersion": "2014-04-01",
-                            "name": "[variables('autoscaleSettingsNameBYOL')]",
-                            "location": "[variables('location')]",
-                            "properties": {
-                                "name": "[variables('autoscaleSettingsNameBYOL')]",
-                                "targetResourceUri": "[concat('/subscriptions/',subscription().subscriptionId, '/resourceGroups/',  variables('vNetResourceGroupName'), '/providers/Microsoft.Compute/virtualMachineScaleSets/', variables('vmssNameBYOL'))]",
-                                "enabled": false,
-                                "profiles": [
-                                    {
-                                        "name": "[concat(variables('uniqueResourceNamePrefix'),'-deployed-profile')]",
-                                        "capacity": {
-                                            "minimum": "[parameters('MinBYOLInstanceCount')]",
-                                            "maximum": "[parameters('MaxBYOLInstanceCount')]",
-                                            "default": "[parameters('BYOLInstanceCount')]"
-                                        },
-                                        "rules": "[variables('autoscaleSettingsPresets')[variables('licensingModel')].byol]"
-                                    }
-                                ]
-                            }
-                        },
-                        {
-                            "dependsOn": [
-                                "[variables('vmssNamePAYG')]",
-                                "[variables('autoscaleSettingsNameBYOL')]"
-                            ],
-                            "type": "Microsoft.Insights/autoscaleSettings",
-                            "apiVersion": "2014-04-01",
-                            "name": "[variables('autoscaleSettingsNamePAYG')]",
-                            "location": "[variables('location')]",
-                            "properties": {
-                                "name": "[variables('autoscaleSettingsNamePAYG')]",
-                                "targetResourceUri": "[concat('/subscriptions/',subscription().subscriptionId, '/resourceGroups/',  variables('vNetResourceGroupName'), '/providers/Microsoft.Compute/virtualMachineScaleSets/', variables('vmssNamePAYG'))]",
-                                "enabled": false,
-                                "profiles": [
-                                    {
-                                        "name": "[concat(variables('uniqueResourceNamePrefix'),'-deployed-profile')]",
-                                        "capacity": {
-                                            "minimum": "[parameters('MinPAYGInstanceCount')]",
-                                            "maximum": "[parameters('MaxPAYGInstanceCount')]",
-                                            "default": "[parameters('PAYGInstanceCount')]"
-                                        },
-                                        "rules": "[variables('autoscaleSettingsPresets')[variables('licensingModel')].payg]"
-                                    }
-                                ]
-                            }
-                        }
-                    ]
+                "templateLink": {
+                    "uri": "https://raw.githubusercontent.com/fortinet/fortigate-autoscale-azure/3.3.0-dev.0/templates/linked_template.vmss.json"
+                },
+                "parameters": {
+                    "AdminUsername": {
+                        "value": "[parameters('AdminUsername')]"
+                    },
+                    "AdminPassword": {
+                        "value": "[parameters('AdminPassword')]"
+                    },
+                    "BYOLInstanceCount": {
+                        "value": "[parameters('BYOLInstanceCount')]"
+                    },
+                    "ExtLBInboundNatPoolHTTPSBYOL": {
+                        "value": "[variables('extLBInboundNatPoolHTTPSBYOL')]"
+                    },
+                    "ExtLBInboundNatPoolHTTPSPAYG": {
+                        "value": "[variables('extLBInboundNatPoolHTTPSPAYG')]"
+                    },
+                    "ExtLBInboundNatPoolSSHBYOL": {
+                        "value": "[variables('extLBInboundNatPoolSSHBYOL')]"
+                    },
+                    "ExtLBInboundNatPoolSSHPAYG": {
+                        "value": "[variables('extLBInboundNatPoolSSHPAYG')]"
+                    },
+                    "ExternalLoadBalancerName": {
+                        "value": "[variables('externalLoadBalancerName')]"
+                    },
+                    "FgtVmImageBYOL": {
+                        "value": "[variables('fgtvmImageBYOL')]"
+                    },
+                    "FgtVmImagePAYG": {
+                        "value": "[variables('fgtvmImagePAYG')]"
+                    },
+                    "FOSVersion": {
+                        "value": "[parameters('FOSVersion')]"
+                    },
+                    "FunctioinEndpointAutoscaleHandler": {
+                        "value": "[variables('autoscaleEndpointFgtAsHandler')]"
+                    },
+                    "FunctioinEndpointByolLicense": {
+                        "value": "[variables('autoscaleEndpointByolLicense')]"
+                    },
+                    "FunctionAppName": {
+                        "value": "[variables('functionAppName')]"
+                    },
+                    "FunctionAppResourceGroupName": {
+                        "value": "[resourceGroup().name]"
+                    },
+                    "InstanceType": {
+                        "value": "[parameters('InstanceType')]"
+                    },
+                    "InternalLoadBalancerName": {
+                        "value": "[variables('internalLoadBalancerName')]"
+                    },
+                    "LicensingModel": {
+                        "value": "[variables('licensingModel')]"
+                    },
+                    "LoadBalancerBackendIPPoolNameSubnet1": {
+                        "value": "[variables('loadBalancerBackendIPPoolNameSubnet1')]"
+                    },
+                    "LoadBalancerBackendIPPoolNameSubnet2": {
+                        "value": "[variables('loadBalancerBackendIPPoolNameSubnet2')]"
+                    },
+                    "LoadBalancerBackendIPPoolNameSubnet3": {
+                        "value": "[variables('loadBalancerBackendIPPoolNameSubnet3')]"
+                    },
+                    "LoadBalancerBackendIPPoolNameSubnet4": {
+                        "value": "[variables('loadBalancerBackendIPPoolNameSubnet4')]"
+                    },
+                    "MaxBYOLInstanceCount": {
+                        "value": "[parameters('MaxBYOLInstanceCount')]"
+                    },
+                    "MaxPAYGInstanceCount": {
+                        "value": "[parameters('MaxPAYGInstanceCount')]"
+                    },
+                    "MinBYOLInstanceCount": {
+                        "value": "[parameters('MinBYOLInstanceCount')]"
+                    },
+                    "MinPAYGInstanceCount": {
+                        "value": "[parameters('MinPAYGInstanceCount')]"
+                    },
+                    "PAYGInstanceCount": {
+                        "value": "[parameters('PAYGInstanceCount')]"
+                    },
+                    "ResourceNamePrefix": {
+                        "value": "[parameters('ResourceNamePrefix')]"
+                    },
+                    "ScaleInThreshold": {
+                        "value": "[parameters('ScaleInThreshold')]"
+                    },
+                    "ScaleOutThreshold": {
+                        "value": "[parameters('ScaleOutThreshold')]"
+                    },
+                    "StorageAccountName": {
+                        "value": "[variables('storageAccountName')]"
+                    },
+                    "Subnet1Name": {
+                        "value": "[variables('subnet1Name')]"
+                    },
+                    "Subnet2Name": {
+                        "value": "[variables('subnet2Name')]"
+                    },
+                    "Subnet3Name": {
+                        "value": "[variables('subnet3Name')]"
+                    },
+                    "Subnet4Name": {
+                        "value": "[variables('subnet4Name')]"
+                    },
+                    "UniqueResourceNamePrefix": {
+                        "value": "[variables('uniqueResourceNamePrefix')]"
+                    },
+                    "VnetName": {
+                        "value": "[variables('vNetName')]"
+                    },
+                    "VnetResourceGroupName": {
+                        "value": "[variables('vNetResourceGroupName')]"
+                    }
                 }
             },
             "subscriptionId": "[subscription().subscriptionId]",
-            "resourceGroup": "[variables('resourceGroupName')]"
+            "resourceGroup": "[resourceGroup().name]"
         }
     ],
     "outputs": {
-        "deploymentPackageVersion": {
-            "type": "string",
-            "value": "3.3.0"
-        },
-        "uniqueResourceNamePrefix": {
-            "type": "String",
-            "value": "[variables('uniqueResourceNamePrefix')]"
-        },
-        "resourceGroupName": {
-            "type": "String",
-            "value": "[variables('resourceGroupName')]"
-        },
-        "vNetResourceGroupName": {
-            "type": "String",
-            "value": "[variables('vNetResourceGroupName')]"
-        },
-        "storageAccountName": {
-            "type": "String",
-            "value": "[variables('storageAccountName')]"
-        },
         "autoscaleAssetContainerName": {
             "type": "String",
             "value": "[variables('autoscaleAssetContainerName')]"
         },
-        "byolScaleSetName": {
-            "type": "String",
-            "value": "[variables('vmssNameBYOL')]"
-        },
         "byolAutoscaleSettingsName": {
             "type": "String",
-            "value": "[variables('autoscaleSettingsNameBYOL')]"
-        },
-        "paygAutoscaleSettingsName": {
-            "type": "String",
-            "value": "[variables('autoscaleSettingsNamePAYG')]"
-        },
-        "paygScaleSetName": {
-            "type": "String",
-            "value": "[variables('vmssNamePAYG')]"
-        },
-        "licenseFileDirectory": {
-            "type": "String",
-            "value": "[variables('licenseFileDirectory')]"
+            "value": "[reference('CreateVirtualMachineScaleSet').outputs.byolAutoscaleSettingsName.value]"
         },
         "byolScaleSetDefaultSize": {
             "type": "Int",
-            "value": "[parameters('BYOLInstanceCount')]"
-        },
-        "byolScaleSetMinSize": {
-            "type": "Int",
-            "value": "[parameters('MinBYOLInstanceCount')]"
+            "value": "[reference('CreateVirtualMachineScaleSet').outputs.byolScaleSetDefaultSize.value]"
         },
         "byolScaleSetMaxSize": {
             "type": "Int",
-            "value": "[parameters('MaxBYOLInstanceCount')]"
+            "value": "[reference('CreateVirtualMachineScaleSet').outputs.byolScaleSetMaxSize.value]"
         },
-        "paygScaleSetDefaultSize": {
+        "byolScaleSetMinSize": {
             "type": "Int",
-            "value": "[parameters('PAYGInstanceCount')]"
+            "value": "[reference('CreateVirtualMachineScaleSet').outputs.byolScaleSetMinSize.value]"
         },
-        "paygScaleSetMinSize": {
-            "type": "Int",
-            "value": "[parameters('MinPAYGInstanceCount')]"
-        },
-        "paygScaleSetMaxSize": {
-            "type": "Int",
-            "value": "[parameters('MaxPAYGInstanceCount')]"
-        },
-        "fgtLicensingModel": {
+        "byolScaleSetName": {
             "type": "String",
-            "value": "[variables('licensingModelName')]"
-        },
-        "fazPublicIp": {
-            "type": "String",
-            "value": "[if(variables('enableFortiAnalyzer'), reference('FortiAnalyzerIntegrationResources').outputs.fazPublicIp.value, 'n/a')]"
+            "value": "[reference('CreateVirtualMachineScaleSet').outputs.byolScaleSetName.value]"
         },
         "cmdDeleteAutoscale": {
             "type": "String",
             "value": "[variables('cmdDeleteAutoscaleAll')]"
         },
-        "cmdVNetCleanUp": {
+        "cmdDeleteAutoscaleSettings": {
             "type": "String",
-            "value": "[variables('cmdVNetCleanUp')]"
+            "value": "[reference('CreateVirtualMachineScaleSet').outputs.cmdDeleteAutoscaleSettings.value]"
+        },
+        "deploymentPackageVersion": {
+            "type": "string",
+            "value": "3.3.0"
+        },
+        "fazPublicIp": {
+            "type": "String",
+            "value": "[if(variables('enableFortiAnalyzer'), reference('FortiAnalyzerIntegrationResources').outputs.fazPublicIp.value, 'n/a')]"
+        },
+        "fgtLicensingModel": {
+            "type": "String",
+            "value": "[variables('licensingModelName')]"
+        },
+        "licenseFileDirectory": {
+            "type": "String",
+            "value": "[variables('licenseFileDirectory')]"
+        },
+        "paygAutoscaleSettingsName": {
+            "type": "String",
+            "value": "[reference('CreateVirtualMachineScaleSet').outputs.paygAutoscaleSettingsName.value]"
+        },
+        "paygScaleSetDefaultSize": {
+            "type": "Int",
+            "value": "[reference('CreateVirtualMachineScaleSet').outputs.paygScaleSetDefaultSize.value]"
+        },
+        "paygScaleSetMaxSize": {
+            "type": "Int",
+            "value": "[reference('CreateVirtualMachineScaleSet').outputs.paygScaleSetMaxSize.value]"
+        },
+        "paygScaleSetMinSize": {
+            "type": "Int",
+            "value": "[reference('CreateVirtualMachineScaleSet').outputs.paygScaleSetMinSize.value]"
+        },
+        "paygScaleSetName": {
+            "type": "String",
+            "value": "[reference('CreateVirtualMachineScaleSet').outputs.paygScaleSetName.value]"
+        },
+        "resourceGroupName": {
+            "type": "String",
+            "value": "[resourceGroup().name]"
+        },
+        "storageAccountName": {
+            "type": "String",
+            "value": "[variables('storageAccountName')]"
+        },
+        "uniqueResourceNamePrefix": {
+            "type": "String",
+            "value": "[variables('uniqueResourceNamePrefix')]"
+        },
+        "vNetResourceGroupName": {
+            "type": "String",
+            "value": "[variables('vNetResourceGroupName')]"
         }
     }
 }

--- a/templates/deploy_fortigate_autoscale.hybrid_licensing.json
+++ b/templates/deploy_fortigate_autoscale.hybrid_licensing.json
@@ -2,107 +2,87 @@
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "3.3.0.0",
     "parameters": {
-        "ResourceNamePrefix": {
-            "maxLength": 10,
-            "type": "String",
-            "metadata": {
-                "description": "The prefix for all applicable resource names. Can only contain uppercase letters, lowercase letters, and numbers. Maximum length is 10."
-            }
-        },
-        "VnetDeploymentMethod": {
-            "defaultValue": "create a new VNet in the Autoscale resource group",
-            "allowedValues": [
-                "create a new VNet in the Autoscale resource group",
-                "create a new VNet in the specified VNet resource group",
-                "use existing VNet in the specified VNet resource group"
-            ],
-            "type": "String",
-            "metadata": {
-                "description": "Options for Virtual Network (VNet) deployment. The Autoscale resource group is the one specified in the 'Resource group' parameter. The VNet resource group is the one specified in the 'VNet Resource Group Name' parameter. For requirements when using an existing resource group, refer to the documentation."
-            }
-        },
-        "VnetResourceGroupName": {
+        "AccessRestrictionIPRange": {
             "defaultValue": "",
             "type": "String",
             "metadata": {
-                "description": "Name of the resource group that contains the VNet and related network components. Required if the VNet is not in the Autoscale resource group. For details refer to the description for the parameter VNet Deployment Method. This resource group must be in the same region as the Autoscale resource group."
+                "description": "Specify IP ranges (single IPv4 or CIDR range) to allow access from the Internet or from your on-premises network to the CosmosDB and Function App. Specify at least one entry for security purposes. For multiple entries, each entry must be separated by a comma and no trailing comma is allowed. **WARNING!** 0.0.0.0/0 accepts connections from any IP address. We recommend that you use a constrained CIDR range to reduce the potential of inbound attacks from unknown IP addresses."
             }
         },
-        "VnetName": {
-            "defaultValue": "",
-            "type": "String",
+        "AdminPassword": {
+            "type": "SecureString",
             "metadata": {
-                "description": "Name of the Azure VNet to connect to FortiGate Autoscale. Required when using an existing VNet. When creating a new VNet, this parameter can be left empty and a name will be generated."
+                "description": "FortiGate administrator password on all VMs as well as the FortiAnalyzer if FortiAnalyzer integration enabled. This field must be between 11 and 26 characters and must include at least one uppercase letter, one lowercase letter, one digit, and one special character such as (! @ # $ %)."
             }
         },
-        "VnetAddressSpace": {
-            "defaultValue": "10.0.0.0/16",
+        "AdminUsername": {
+            "defaultValue": "azureadmin",
             "type": "String",
             "metadata": {
-                "description": "IP address space of the VNet in CIDR notation. E.g. 10.0.0.0/16. Required when using an existing VNet. The value should match the address space of the target VNet."
+                "description": "FortiGate administrator username on all VMs as well as the FortiAnalyzer if FortiAnalyzer integration enabled."
             }
         },
-        "Subnet1Name": {
-            "defaultValue": "",
-            "type": "String",
+        "BYOLInstanceCount": {
+            "defaultValue": 2,
+            "minValue": 0,
+            "type": "Int",
             "metadata": {
-                "description": "Subnet 1 name. The subnet in which to deploy the FortiGate VMSS. Required when using an existing VNet. The value should match the subnet of the target VNet. When creating a new VNet, any input value will be ignored."
+                "description": "The number of FortiGate instances the BYOL VMSS should have at any time. For High Availability in BYOL-only and Hybrid use cases, ensure at least 2 FortiGates are in the group. For specific use cases, set to 0 for PAYG-only, and >= 2 for BYOL-only or hybrid licensing."
             }
         },
-        "Subnet1AddressRange": {
-            "defaultValue": "10.0.0.0/24",
+        "FOSVersion": {
+            "defaultValue": "6.4.5",
+            "allowedValues": ["6.4.5"],
             "type": "String",
             "metadata": {
-                "description": "When deploying to a new VNet, this defines the address range for subnet 1 in CIDR notation (e.g. 10.0.0.0/24). It must be contained by the address space of the virtual network. The address range of a subnet which is in use can't be edited. When using an existing VNet, the value should match the subnet of the target VNet."
+                "description": "FortiOS version supported by FortiGate Autoscale for Azure."
             }
         },
-        "Subnet2Name": {
-            "defaultValue": "",
-            "type": "String",
+        "FortiAnalyzerAutoscaleAdminPassword": {
+            "type": "securestring",
             "metadata": {
-                "description": "Subnet 2 name. One of the subnets to be protected by the FortiGate. Required when using an existing VNet. The value should match the subnet of the target VNet. When creating a new VNet, any input value will be ignored."
+                "description": "The password for the 'Autoscale admin username'. The password must conform to the FortiAnalyzer password policy and have a min length of 8 and a max length 128. If you need to enable KMS encryption, refer to the documentation."
             }
         },
-        "Subnet2AddressRange": {
-            "defaultValue": "10.0.1.0/24",
-            "type": "String",
+        "FortiAnalyzerAutoscaleAdminUsername": {
+            "type": "string",
             "metadata": {
-                "description": "When deploying to a new VNet, this defines the address range for subnet 2 in CIDR notation (e.g. 10.0.1.0/24). It must be contained by the address space of the virtual network. The address range of a subnet which is in use can't be edited. When using an existing VNet, the value should match the subnet of the target VNet."
+                "description": "This FortiAnalyzer account name can include numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen (-)."
             }
         },
-        "Subnet3Name": {
-            "defaultValue": "",
-            "type": "String",
+        "FortiAnalyzerCustomPrivateIpAddress": {
+            "type": "string",
             "metadata": {
-                "description": "Subnet 3 name. One of the subnets to be protected by the FortiGate. Required when using an existing VNet. The value should match the subnet of the target VNet. When creating a new VNet, any input value will be ignored."
+                "description": "The custom private IP address to be used by the FortiAnalyzer. Must be within the Public subnet 1 CIDR range. Required if 'FortiAnalyzer Integration' is set to 'yes'. If 'FortiAnalyzer Integration' is set to 'no', any input will be ignored."
             }
         },
-        "Subnet3AddressRange": {
-            "defaultValue": "10.0.2.0/24",
+        "FortiAnalyzerInstanceType": {
+            "defaultValue": "Standard_D2",
             "type": "String",
             "metadata": {
-                "description": "When deploying to a new VNet, this defines the address range for subnet 3 in CIDR notation (e.g. 10.0.2.0/24). It must be contained by the address space of the virtual network. The address range of a subnet which is in use can't be edited. When using an existing VNet, the value should match the subnet of the target VNet."
+                "description": "Size of the FortiAnalyzer VM."
             }
         },
-        "Subnet4Name": {
-            "defaultValue": "",
+        "FortiAnalyzerIntegrationOptions": {
+            "defaultValue": "yes",
+            "allowedValues": ["yes", "no"],
             "type": "String",
             "metadata": {
-                "description": "Subnet 4 name. One of the subnets to be protected by the FortiGate. Required when using an existing VNet. The value should match the subnet of the target VNet. When creating a new VNet, any input value will be ignored."
+                "description": "Choose 'yes' to incorporate FortiAnalyzer into Fortinet FortiGate Auto Scaling to use extended features that include storing logs into FortiAnalyzer."
             }
         },
-        "Subnet4AddressRange": {
-            "defaultValue": "10.0.3.0/24",
+        "FortiAnalyzerVersion": {
+            "defaultValue": "6.4.4",
+            "allowedValues": ["6.4.4", "6.2.5"],
             "type": "String",
             "metadata": {
-                "description": "When deploying to a new VNet, this defines the address range for subnet 4 in CIDR notation (e.g. 10.0.3.0/24). It must be contained by the address space of the virtual network. The address range of a subnet which is in use can't be edited. When using an existing VNet, the value should match the subnet of the target VNet."
+                "description": "The FortiAnalyzer version supported by Fortinet FortiGate Auto Scaling."
             }
         },
-        "NetworkSecurityGroupName": {
-            "defaultValue": "",
-            "type": "String",
+        "FortiGatePSKSecret": {
+            "type": "SecureString",
             "metadata": {
-                "description": "The name of the Network Security Group associated with the subnets in the VNet. Required when using an existing VNet. The value should match the name of the existing Network Security Group associated with the subnets in the VNet. When creating a new VNet, you may specify a name for the Network Security Group. If left empty a name will be generated."
+                "description": "The secret key for the FortiGates instances to securely communicate with each other. Must contain numbers and letters and may contain special characters. Maximum length is 128."
             }
         },
         "FrontendIPDeploymentMethod": {
@@ -120,148 +100,12 @@
                 "description": "Name of the Frontend Public IP address. When the 'Frontend IP Deployment Method' parameter is set to 'create new public IP address, this parameter can be left empty and a name will be generated."
             }
         },
-        "LoadBalancerIP": {
-            "defaultValue": "10",
-            "type": "String",
-            "metadata": {
-                "description": "The last octet of the Frontend Private IP address to be used by the Load Balancer. For example, if set to 10, the Private IP for the Load Balancer in the subnet with prefix 10.0.1.0/24 would be 10.0.1.10."
-            }
-        },
-        "InstanceType": {
-            "defaultValue": "Standard_F4",
-            "allowedValues": ["Standard_F4s_v2", "Standard_F4s", "Standard_F4"],
-            "type": "String",
-            "metadata": {
-                "description": "Size of the VMs in the VMSS."
-            }
-        },
-        "FOSVersion": {
-            "defaultValue": "6.4.5",
-            "allowedValues": ["6.4.5"],
-            "type": "String",
-            "metadata": {
-                "description": "FortiOS version supported by FortiGate Autoscale for Azure."
-            }
-        },
-        "FortiGatePSKSecret": {
-            "type": "SecureString",
-            "metadata": {
-                "description": "The secret key for the FortiGates instances to securely communicate with each other. Must contain numbers and letters and may contain special characters. Maximum length is 128."
-            }
-        },
-        "AdminUsername": {
-            "defaultValue": "azureadmin",
-            "type": "String",
-            "metadata": {
-                "description": "FortiGate administrator username on all VMs as well as the FortiAnalyzer if FortiAnalyzer integration enabled."
-            }
-        },
-        "AdminPassword": {
-            "type": "SecureString",
-            "metadata": {
-                "description": "FortiGate administrator password on all VMs as well as the FortiAnalyzer if FortiAnalyzer integration enabled. This field must be between 11 and 26 characters and must include at least one uppercase letter, one lowercase letter, one digit, and one special character such as (! @ # $ %)."
-            }
-        },
-        "AccessRestrictionIPRange": {
-            "defaultValue": "",
-            "type": "String",
-            "metadata": {
-                "description": "Specify IP ranges (single IPv4 or CIDR range) to allow access from the Internet or from your on-premises network to the CosmosDB and Function App. Specify at least one entry for security purposes. For multiple entries, each entry must be separated by a comma and no trailing comma is allowed. **WARNING!** 0.0.0.0/0 accepts connections from any IP address. We recommend that you use a constrained CIDR range to reduce the potential of inbound attacks from unknown IP addresses."
-            }
-        },
-        "StorageAccountType": {
-            "defaultValue": "Standard_LRS",
-            "allowedValues": ["Standard_LRS", "Standard_GRS", "Standard_RAGRS"],
-            "type": "String",
-            "metadata": {
-                "description": "Storage account type."
-            }
-        },
-        "ServicePrincipalObjectID": {
-            "type": "String",
-            "metadata": {
-                "description": "Object ID for the Registered app used as Autosccale Function App API request service principal. This is under Azure Active Directory > App registrations > {your app}."
-            }
-        },
-        "ServicePrincipalAppID": {
-            "type": "String",
-            "metadata": {
-                "description": "Application ID for the Registered app used as Autosccale Function App API request service principal. This is under Azure Active Directory > App registrations > {your app}."
-            }
-        },
-        "ServicePrincipalAppSecret": {
-            "type": "String",
-            "metadata": {
-                "description": "Password (Authentication key) for the Registered app used as Autosccale Function App API request service principal."
-            }
-        },
-        "BYOLInstanceCount": {
-            "defaultValue": 2,
-            "minValue": 0,
+        "HeartBeatDelayAllowance": {
+            "defaultValue": 30,
+            "minValue": 30,
             "type": "Int",
             "metadata": {
-                "description": "The number of FortiGate instances the BYOL VMSS should have at any time. For High Availability in BYOL-only and Hybrid use cases, ensure at least 2 FortiGates are in the group. For specific use cases, set to 0 for PAYG-only, and >= 2 for BYOL-only or hybrid licensing."
-            }
-        },
-        "MinBYOLInstanceCount": {
-            "defaultValue": 2,
-            "minValue": 0,
-            "type": "Int",
-            "metadata": {
-                "description": "Minimum number of FortiGate instances in the BYOL VMSS. For specific use cases, set to 0 for PAYG-only, and >= 2 for BYOL-only or hybrid licensing."
-            }
-        },
-        "MaxBYOLInstanceCount": {
-            "defaultValue": 2,
-            "minValue": 0,
-            "type": "Int",
-            "metadata": {
-                "description": "Maximum number of FortiGate instances in the BYOL VMSS. For specific use cases, set to 0 for PAYG-only, and >= 2 for BYOL-only or hybrid licensing. This number must be greater than or equal to the 'Min BYOL Instance Count'."
-            }
-        },
-        "PAYGInstanceCount": {
-            "defaultValue": 0,
-            "minValue": 0,
-            "type": "Int",
-            "metadata": {
-                "description": "The number of FortiGate instances the PAYG VMSS should have at any time. For High Availability in a PAYG-only use case, ensure at least 2 FortiGates are in the group. For specific use cases, set to 0 for BYOL-only, >= 2 for PAYG-only, and >= 0 for hybrid licensing."
-            }
-        },
-        "MinPAYGInstanceCount": {
-            "defaultValue": 0,
-            "minValue": 0,
-            "type": "Int",
-            "metadata": {
-                "description": "Minimum number of FortiGate instances in the PAYG VMSS. For specific use cases, set to 0 for BYOL-only, >= 2 for PAYG-only, and >= 0 for hybrid licensing."
-            }
-        },
-        "MaxPAYGInstanceCount": {
-            "defaultValue": 6,
-            "minValue": 0,
-            "type": "Int",
-            "metadata": {
-                "description": "Maximum number of FortiGate instances in the PAYG VMSS. For specific use cases, set to 0 for BYOL-only, >= 2 for PAYG-only, and >= 0 for hybrid licensing. This number must be greater than or equal to the 'Min PAYG Instance Count'."
-            }
-        },
-        "ScaleOutThreshold": {
-            "defaultValue": 80,
-            "type": "Int",
-            "metadata": {
-                "description": "Percentage of CPU utilization at which scale-out should occur."
-            }
-        },
-        "ScaleInThreshold": {
-            "defaultValue": 20,
-            "type": "Int",
-            "metadata": {
-                "description": "Percentage of CPU utilization at which scale-in should occur."
-            }
-        },
-        "PrimaryElectionTimeout": {
-            "defaultValue": 600,
-            "type": "Int",
-            "metadata": {
-                "description": "The maximum time (in seconds) to wait for a primary election to complete."
+                "description": "The maximum amount of time (in seconds) allowed for network latency of the FortiGate heartbeat arriving at the Autoscale handler function. Minimum is 30."
             }
         },
         "HeartBeatInterval": {
@@ -281,12 +125,101 @@
                 "description": "Number of consecutively lost heartbeats. When the Heart Beat Loss Count has been reached, the VM is deemed unhealthy and failover activities will commence."
             }
         },
-        "HeartBeatDelayAllowance": {
-            "defaultValue": 30,
-            "minValue": 30,
+        "InstanceType": {
+            "defaultValue": "Standard_F4",
+            "allowedValues": ["Standard_F4s_v2", "Standard_F4s", "Standard_F4"],
+            "type": "String",
+            "metadata": {
+                "description": "Size of the VMs in the VMSS."
+            }
+        },
+        "LoadBalancerIP": {
+            "defaultValue": "10",
+            "type": "String",
+            "metadata": {
+                "description": "The last octet of the Frontend Private IP address to be used by the Load Balancer. For example, if set to 10, the Private IP for the Load Balancer in the subnet with prefix 10.0.1.0/24 would be 10.0.1.10."
+            }
+        },
+        "MaxBYOLInstanceCount": {
+            "defaultValue": 2,
+            "minValue": 0,
             "type": "Int",
             "metadata": {
-                "description": "The maximum amount of time (in seconds) allowed for network latency of the FortiGate heartbeat arriving at the Autoscale handler function. Minimum is 30."
+                "description": "Maximum number of FortiGate instances in the BYOL VMSS. For specific use cases, set to 0 for PAYG-only, and >= 2 for BYOL-only or hybrid licensing. This number must be greater than or equal to the 'Min BYOL Instance Count'."
+            }
+        },
+        "MaxPAYGInstanceCount": {
+            "defaultValue": 6,
+            "minValue": 0,
+            "type": "Int",
+            "metadata": {
+                "description": "Maximum number of FortiGate instances in the PAYG VMSS. For specific use cases, set to 0 for BYOL-only, >= 2 for PAYG-only, and >= 0 for hybrid licensing. This number must be greater than or equal to the 'Min PAYG Instance Count'."
+            }
+        },
+        "MinBYOLInstanceCount": {
+            "defaultValue": 2,
+            "minValue": 0,
+            "type": "Int",
+            "metadata": {
+                "description": "Minimum number of FortiGate instances in the BYOL VMSS. For specific use cases, set to 0 for PAYG-only, and >= 2 for BYOL-only or hybrid licensing."
+            }
+        },
+        "MinPAYGInstanceCount": {
+            "defaultValue": 0,
+            "minValue": 0,
+            "type": "Int",
+            "metadata": {
+                "description": "Minimum number of FortiGate instances in the PAYG VMSS. For specific use cases, set to 0 for BYOL-only, >= 2 for PAYG-only, and >= 0 for hybrid licensing."
+            }
+        },
+        "NetworkSecurityGroupName": {
+            "defaultValue": "",
+            "type": "String",
+            "metadata": {
+                "description": "The name of the Network Security Group associated with the subnets in the VNet. Required when using an existing VNet. The value should match the name of the existing Network Security Group associated with the subnets in the VNet. When creating a new VNet, you may specify a name for the Network Security Group. If left empty a name will be generated."
+            }
+        },
+        "PAYGInstanceCount": {
+            "defaultValue": 0,
+            "minValue": 0,
+            "type": "Int",
+            "metadata": {
+                "description": "The number of FortiGate instances the PAYG VMSS should have at any time. For High Availability in a PAYG-only use case, ensure at least 2 FortiGates are in the group. For specific use cases, set to 0 for BYOL-only, >= 2 for PAYG-only, and >= 0 for hybrid licensing."
+            }
+        },
+        "PackageResURL": {
+            "type": "String",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The public URL of the deployment package zip file that contains the resource used to deploy the Function App. This URL must be accessible by Azure. The default URL points to the GitHub release corresponding to this ARM template contentVersion."
+            }
+        },
+        "PrimaryElectionTimeout": {
+            "defaultValue": 600,
+            "type": "Int",
+            "metadata": {
+                "description": "The maximum time (in seconds) to wait for a primary election to complete."
+            }
+        },
+        "ResourceNamePrefix": {
+            "maxLength": 10,
+            "type": "String",
+            "metadata": {
+                "description": "The prefix for all applicable resource names. Can only contain uppercase letters, lowercase letters, and numbers. Maximum length is 10."
+            }
+        },
+        "ScaleInThreshold": {
+            "defaultValue": 20,
+            "type": "Int",
+            "metadata": {
+                "description": "Percentage of CPU utilization at which scale-in should occur."
+            }
+        },
+        "ScaleOutThreshold": {
+            "defaultValue": 80,
+            "type": "Int",
+            "metadata": {
+                "description": "Percentage of CPU utilization at which scale-out should occur."
             }
         },
         "ServicePlanTier": {
@@ -297,52 +230,115 @@
                 "description": "The pricing tier for the function service plan. Note: the Free plan is for trial and demo only. Do not use it in production."
             }
         },
-        "PackageResURL": {
+        "ServicePrincipalAppID": {
             "type": "String",
+            "metadata": {
+                "description": "Application ID for the Registered app used as Autosccale Function App API request service principal. This is under Azure Active Directory > App registrations > {your app}."
+            }
+        },
+        "ServicePrincipalAppSecret": {
+            "type": "String",
+            "metadata": {
+                "description": "Password (Authentication key) for the Registered app used as Autosccale Function App API request service principal."
+            }
+        },
+        "ServicePrincipalObjectID": {
+            "type": "String",
+            "metadata": {
+                "description": "Object ID for the Registered app used as Autosccale Function App API request service principal. This is under Azure Active Directory > App registrations > {your app}."
+            }
+        },
+        "StorageAccountType": {
+            "defaultValue": "Standard_LRS",
+            "allowedValues": ["Standard_LRS", "Standard_GRS", "Standard_RAGRS"],
+            "type": "String",
+            "metadata": {
+                "description": "Storage account type."
+            }
+        },
+        "Subnet1AddressRange": {
+            "defaultValue": "10.0.0.0/24",
+            "type": "String",
+            "metadata": {
+                "description": "When deploying to a new VNet, this defines the address range for subnet 1 in CIDR notation (e.g. 10.0.0.0/24). It must be contained by the address space of the virtual network. The address range of a subnet which is in use can't be edited. When using an existing VNet, the value should match the subnet of the target VNet."
+            }
+        },
+        "Subnet1Name": {
             "defaultValue": "",
-            "metadata": {
-                "description": "The public URL of the deployment package zip file that contains the resource used to deploy the Function App. This URL must be accessible by Azure. The default URL points to the GitHub release corresponding to this ARM template contentVersion."
-            }
-        },
-        "FortiAnalyzerIntegrationOptions": {
-            "defaultValue": "yes",
-            "allowedValues": ["yes", "no"],
             "type": "String",
             "metadata": {
-                "description": "Choose 'yes' to incorporate FortiAnalyzer into Fortinet FortiGate Auto Scaling to use extended features that include storing logs into FortiAnalyzer."
+                "description": "Subnet 1 name. The subnet in which to deploy the FortiGate VMSS. Required when using an existing VNet. The value should match the subnet of the target VNet. When creating a new VNet, any input value will be ignored."
             }
         },
-        "FortiAnalyzerInstanceType": {
-            "defaultValue": "Standard_D2",
+        "Subnet2AddressRange": {
+            "defaultValue": "10.0.1.0/24",
             "type": "String",
             "metadata": {
-                "description": "Size of the FortiAnalyzer VM."
+                "description": "When deploying to a new VNet, this defines the address range for subnet 2 in CIDR notation (e.g. 10.0.1.0/24). It must be contained by the address space of the virtual network. The address range of a subnet which is in use can't be edited. When using an existing VNet, the value should match the subnet of the target VNet."
             }
         },
-        "FortiAnalyzerVersion": {
-            "defaultValue": "6.4.2",
-            "allowedValues": ["6.4.2", "6.2.5"],
+        "Subnet2Name": {
+            "defaultValue": "",
             "type": "String",
             "metadata": {
-                "description": "The FortiAnalyzer version supported by Fortinet FortiGate Auto Scaling."
+                "description": "Subnet 2 name. One of the subnets to be protected by the FortiGate. Required when using an existing VNet. The value should match the subnet of the target VNet. When creating a new VNet, any input value will be ignored."
             }
         },
-        "FortiAnalyzerCustomPrivateIpAddress": {
-            "type": "string",
+        "Subnet3AddressRange": {
+            "defaultValue": "10.0.2.0/24",
+            "type": "String",
             "metadata": {
-                "description": "The custom private IP address to be used by the FortiAnalyzer. Must be within the Public subnet 1 CIDR range. Required if 'FortiAnalyzer Integration' is set to 'yes'. If 'FortiAnalyzer Integration' is set to 'no', any input will be ignored."
+                "description": "When deploying to a new VNet, this defines the address range for subnet 3 in CIDR notation (e.g. 10.0.2.0/24). It must be contained by the address space of the virtual network. The address range of a subnet which is in use can't be edited. When using an existing VNet, the value should match the subnet of the target VNet."
             }
         },
-        "FortiAnalyzerAutoscaleAdminUsername": {
-            "type": "string",
+        "Subnet3Name": {
+            "defaultValue": "",
+            "type": "String",
             "metadata": {
-                "description": "This FortiAnalyzer account name can include numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen (-)."
+                "description": "Subnet 3 name. One of the subnets to be protected by the FortiGate. Required when using an existing VNet. The value should match the subnet of the target VNet. When creating a new VNet, any input value will be ignored."
             }
         },
-        "FortiAnalyzerAutoscaleAdminPassword": {
-            "type": "securestring",
+        "Subnet4AddressRange": {
+            "defaultValue": "10.0.3.0/24",
+            "type": "String",
             "metadata": {
-                "description": "The password for the 'Autoscale admin username'. The password must conform to the FortiAnalyzer password policy and have a min length of 8 and a max length 128. If you need to enable KMS encryption, refer to the documentation."
+                "description": "When deploying to a new VNet, this defines the address range for subnet 4 in CIDR notation (e.g. 10.0.3.0/24). It must be contained by the address space of the virtual network. The address range of a subnet which is in use can't be edited. When using an existing VNet, the value should match the subnet of the target VNet."
+            }
+        },
+        "Subnet4Name": {
+            "defaultValue": "",
+            "type": "String",
+            "metadata": {
+                "description": "Subnet 4 name. One of the subnets to be protected by the FortiGate. Required when using an existing VNet. The value should match the subnet of the target VNet. When creating a new VNet, any input value will be ignored."
+            }
+        },
+        "VnetAddressSpace": {
+            "defaultValue": "10.0.0.0/16",
+            "type": "String",
+            "metadata": {
+                "description": "IP address space of the VNet in CIDR notation. E.g. 10.0.0.0/16. Required when using an existing VNet. The value should match the address space of the target VNet."
+            }
+        },
+        "VnetDeploymentMethod": {
+            "defaultValue": "create new",
+            "allowedValues": ["create new", "use existing"],
+            "type": "String",
+            "metadata": {
+                "description": "Options for Virtual Network (VNet) deployment. For requirements when using an existing resource group, refer to the documentation."
+            }
+        },
+        "VnetName": {
+            "defaultValue": "",
+            "type": "String",
+            "metadata": {
+                "description": "Name of the Azure VNet to connect to FortiGate Autoscale. Required when using an existing VNet. When creating a new VNet, this parameter can be left empty and a name will be generated."
+            }
+        },
+        "VnetResourceGroupName": {
+            "defaultValue": "",
+            "type": "String",
+            "metadata": {
+                "description": "Name of the resource group that contains the VNet and related network components. Required if the VNet is not in the Autoscale resource group, otherwise, it will use the same resource group as this deployment. For details refer to the description for the parameter VNet Deployment Method. This resource group must be in the same region as the Autoscale resource group."
             }
         }
     },
@@ -351,25 +347,23 @@
         "accessRestrictionIPCount": "[if(empty(parameters('AccessRestrictionIPRange')), 0, length(variables('accessRestrictionIPArray')))]",
         "accessRestrictionIPString": "[if(empty(parameters('AccessRestrictionIPRange')), '', concat(parameters('AccessRestrictionIPRange'), ','))]",
         "autoscaleAssetContainerName": "fortigate-autoscale",
-        "autoscaleEndpointByolLicense": "[concat(variables('funcappURL'), '/api/byol-license')]",
-        "autoscaleEndpointFazHandler": "[concat(variables('funcappURL'), '/api/faz-auth-handler')]",
-        "autoscaleEndpointFgtAsHandler": "[concat(variables('funcappURL'), '/api/fgt-as-handler')]",
-        "cmdDeleteAutoscaleAll": "[concat(variables('cmdDeleteVNetRelatedComponents'), variables('cmdDeleteAutoscaleResourceGroup'))]",
-        "cmdDeleteAutoscaleResourceGroup": "[concat('az account set -s ', subscription().subscriptionId, ';', 'az group delete -y -n ', resourceGroup().name, ';')]",
-        "cmdDeleteLBS": "[concat('az account set -s ', subscription().subscriptionId, ';', 'az network lb delete -g ', variables('vNetResourceGroupName'),' -n ', variables('externalLoadBalancerName'), ';', 'az network lb delete -g ', variables('vNetResourceGroupName'),' -n ', variables('internalLoadBalancerName'), ';')]",
-        "cmdDeleteNetworkSecurityGroup": "[if(variables('ifCreateVNet'), concat('az account set -s ', subscription().subscriptionId, ';', 'az network nsg delete -g ', variables('vNetResourceGroupName'),' -n ', variables('networkSecurityGroupName'), ';'), '')]",
-        "cmdDeletePublicIP": "[if(and(not(variables('ifCreateVNetInSameRSG')), variables('ifCreateNewPublicIP')), concat('az account set -s ', subscription().subscriptionId, ';', 'az network public-ip delete -g ', variables('vNetResourceGroupName'), ' -n ', variables('publicIPAddressName'), ';'), '')]",
-        "cmdDeleteRouteTable1": "[if(variables('ifCreateVNet'), concat('az account set -s ', subscription().subscriptionId, ';', 'az network route-table delete -g ', variables('vNetResourceGroupName'),' -n ', variables('intRouteTable1Name'), ';'), '')]",
-        "cmdDeleteRouteTable2": "[if(variables('ifCreateVNet'), concat('az account set -s ', subscription().subscriptionId, ';', 'az network route-table delete -g ', variables('vNetResourceGroupName'),' -n ', variables('intRouteTable2Name'), ';'), '')]",
-        "cmdDeleteRouteTable3": "[if(variables('ifCreateVNet'), concat('az account set -s ', subscription().subscriptionId, ';', 'az network route-table delete -g ', variables('vNetResourceGroupName'),' -n ', variables('intRouteTable3Name'), ';'), '')]",
+        "cmdDeleteAutoscaleAll": "[concat('az account set -s ', subscription().subscriptionId, ';', variables('cmdDeleteVNetAll'), variables('cmdDeleteDatabaseAll'))]",
+        "cmdDeleteDatabaseAll": "[concat('az account set -s ', subscription().subscriptionId, ';', variables('cmdDeleteDatabase'), variables('cmdDeleteDatabaseAccount'))]",
+        "cmdDeleteDatabase": "[concat('az cosmosdb database delete -y -g ', resourceGroup().name, ' -n ', variables('databaseName'), ';')]",
+        "cmdDeleteDatabaseAccount": "[concat('az cosmosdb delete -y -g ', resourceGroup().name, ' -n ', variables('databaseAccountName'), ';')]",
+        "cmdDeleteLBS": "[concat('az network lb delete -g ', variables('vNetResourceGroupName'),' -n ', variables('externalLoadBalancerName'), ';', 'az network lb delete -g ', variables('vNetResourceGroupName'),' -n ', variables('internalLoadBalancerName'), ';')]",
+        "cmdDeleteNetworkSecurityGroup": "[if(variables('ifCreateVNet'), concat('az network nsg delete -g ', variables('vNetResourceGroupName'),' -n ', variables('networkSecurityGroupName'), ';'), '')]",
+        "cmdDeletePublicIP": "[if(variables('ifCreateNewPublicIP'), concat('az network public-ip delete -g ', variables('vNetResourceGroupName'), ' -n ', variables('publicIPAddressName'), ';'), '')]",
+        "cmdDeleteRouteTable1": "[if(variables('ifCreateVNet'), concat('az network route-table delete -g ', variables('vNetResourceGroupName'),' -n ', variables('intRouteTable1Name'), ';'), '')]",
+        "cmdDeleteRouteTable2": "[if(variables('ifCreateVNet'), concat('az network route-table delete -g ', variables('vNetResourceGroupName'),' -n ', variables('intRouteTable2Name'), ';'), '')]",
+        "cmdDeleteRouteTable3": "[if(variables('ifCreateVNet'), concat('az network route-table delete -g ', variables('vNetResourceGroupName'),' -n ', variables('intRouteTable3Name'), ';'), '')]",
         "cmdDeleteRouteTableAll": "[concat(variables('cmdDeleteRouteTable1'), variables('cmdDeleteRouteTable2'), variables('cmdDeleteRouteTable3'))]",
-        "cmdDeleteVNet": "[if(variables('ifCreateVNet'), concat('az account set -s ', subscription().subscriptionId, ';', 'az network vnet delete -g ', variables('vNetResourceGroupName'),' -n ', variables('vNetName'), ';'), '')]",
-        "cmdDeleteVNetRelatedComponents": "[if(and(not(variables('ifCreateVNetInSameRSG')), variables('ifCreateVNet')), concat('az account set -s ', subscription().subscriptionId, ';', variables('cmdDeleteLBS'), variables('cmdDeleteVNet'), variables('cmdDeleteNetworkSecurityGroup'), variables('cmdDeletePublicIP'), variables('cmdDeleteRouteTableAll')), '')]",
+        "cmdDeleteVNet": "[if(variables('ifCreateVNet'), concat('az network vnet delete -g ', variables('vNetResourceGroupName'),' -n ', variables('vNetName'), ';'), '')]",
+        "cmdDeleteVNetAll": "[if(variables('ifCreateVNet'), concat('az account set -s ', subscription().subscriptionId, ';', variables('cmdDeleteLBS'), variables('cmdDeleteVNet'), variables('cmdDeleteNetworkSecurityGroup'), variables('cmdDeletePublicIP'), variables('cmdDeleteRouteTableAll'), variables('cmdDeleteVNet')), '')]",
         "databaseAccountName": "[concat(toLower(variables('uniqueResourceNamePrefix')),'dba001')]",
         "databaseName": "FortiGateAutoscale",
         "databaseSharedThroughput": "[add(add(variables('databaseSharedThroughputBase'), if(variables('enableHybridLicensing'), 200, 0)), if(variables('enableFortiAnalyzer'), 100, 0))]",
         "databaseSharedThroughputBase": 500,
-        "enableAzureAppInsights": "[contains(variables('functionAppInsightAvailableLocations'), variables('location'))]",
         "enableFortiAnalyzer": "[equals(parameters('FortiAnalyzerIntegrationOptions'), 'yes')]",
         "enableHybridLicensing": true,
         "extLBFrontendIPConfigNameSubnet1": "external-lb-frontend-ip-config-subnet-1",
@@ -420,37 +414,11 @@
                 "name": "allow-FortiGate-subnet"
             }
         ],
-        "funcappURL": "[concat('https://', variables('functionAppName'), '.azurewebsites.net')]",
-        "functionAppInsightAvailableLocations": [
-            "australiaeast",
-            "australiasoutheast",
-            "brazilsouth",
-            "canadacentral",
-            "centralindia",
-            "centralus",
-            "eastasia",
-            "eastus",
-            "eastus2",
-            "francecentral",
-            "japaneast",
-            "koreacentral",
-            "northcentralus",
-            "northeurope",
-            "southafricanorth",
-            "southcentralus",
-            "southeastasia",
-            "switzerlandnorth",
-            "uksouth",
-            "westeurope",
-            "westus",
-            "westus2"
-        ],
         "functionAppName": "[concat(variables('uniqueResourceNamePrefix'),'funcapp')]",
         "ifBYOLOnly": "[and(not(equals(parameters('MaxBYOLInstanceCount'), 0)), not(equals(parameters('MaxBYOLInstanceCount'), 0)), equals(parameters('MinPAYGInstanceCount'), 0), equals(parameters('MaxPAYGInstanceCount'), 0))]",
         "ifCreateNewPublicIP": "[equals(parameters('FrontendIPDeploymentMethod'), 'create new public IP address')]",
-        "ifCreateVNet": "[or(variables('ifCreateVNetInSameRSG'), variables('ifCreateVNetInExistingRSG'))]",
-        "ifCreateVNetInExistingRSG": "[equals(parameters('VnetDeploymentMethod'), 'create a new VNet in the specified VNet resource group')]",
-        "ifCreateVNetInSameRSG": "[equals(parameters('VnetDeploymentMethod'), 'create a new VNet in the Autoscale resource group')]",
+        "ifCreateVNet": "[equals(parameters('VnetDeploymentMethod'), 'create new')]",
+        "ifCreateVNetInSameRSG": "[and(variables('ifCreateVNet'), or(equals(parameters('VnetResourceGroupName'), ''), equals(parameters('VnetResourceGroupName'), resourceGroup().name)))]",
         "ifPAYGOnly": "[equals(parameters('BYOLInstanceCount'), 0)]",
         "intLBFrontendIPConfigNameSubnet2": "internal-lb-frontend-ip-config-subnet-2",
         "intLBFrontendIPConfigNameSubnet3": "internal-lb-frontend-ip-config-subnet-3",
@@ -481,7 +449,6 @@
         "networkSecurityGroupName": "[if(and(variables('ifCreateVNet'), empty(parameters('NetworkSecurityGroupName'))), concat(parameters('ResourceNamePrefix'), '-network-security-group'), if(empty(parameters('NetworkSecurityGroupName')), 'not-applicable', parameters('NetworkSecurityGroupName')))]",
         "publicIPAddressId": "[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', variables('vNetResourceGroupName'), '/providers/Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]",
         "publicIPAddressName": "[if(and(variables('ifCreateNewPublicIP'), empty(parameters('FrontendIPName'))), concat(variables('vNetName'), '-ext-lb-public-ip'), parameters('FrontendIPName'))]",
-        "storageAccountId": "[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Storage/storageAccounts/', variables('storageAccountName'))]",
         "storageAccountName": "[concat(toLower(variables('uniqueResourceNamePrefix')),'sta001')]",
         "subnet1Id": "[concat(variables('vnetID'), '/subnets/', variables('subnet1Name'))]",
         "subnet1Name": "[if(and(variables('ifCreateVNet'), empty(parameters('Subnet1Name'))), concat(variables('vNetName'), '-subnet1'), parameters('Subnet1Name'))]",
@@ -1551,11 +1518,20 @@
                     "uri": "https://raw.githubusercontent.com/fortinet/fortigate-autoscale-azure/3.3.0-dev.0/templates/linked_template.faz_integration.json"
                 },
                 "parameters": {
-                    "UniqueResourceNamePrefix": {
-                        "value": "[variables('uniqueResourceNamePrefix')]"
+                    "AdminPassword": {
+                        "value": "[parameters('AdminPassword')]"
                     },
-                    "SubnetId": {
-                        "value": "[variables('subnet1Id')]"
+                    "AdminUsername": {
+                        "value": "[parameters('AdminUsername')]"
+                    },
+                    "FortiAnalyzerAutoscaleAdminPassword": {
+                        "value": "[parameters('FortiAnalyzerAutoscaleAdminPassword')]"
+                    },
+                    "FortiAnalyzerAutoscaleAdminUsername": {
+                        "value": "[parameters('FortiAnalyzerAutoscaleAdminUsername')]"
+                    },
+                    "FortiAnalyzerCustomPrivateIpAddress": {
+                        "value": "[parameters('FortiAnalyzerCustomPrivateIpAddress')]"
                     },
                     "FortiAnalyzerInstanceType": {
                         "value": "[parameters('FortiAnalyzerInstanceType')]"
@@ -1563,20 +1539,17 @@
                     "FortiAnalyzerVersion": {
                         "value": "[parameters('FortiAnalyzerVersion')]"
                     },
-                    "FortiAnalyzerCustomPrivateIpAddress": {
-                        "value": "[parameters('FortiAnalyzerCustomPrivateIpAddress')]"
+                    "Location": {
+                        "value": "[resourceGroup().location]"
                     },
-                    "AdminUsername": {
-                        "value": "[parameters('AdminUsername')]"
+                    "ResourceGroupName": {
+                        "value": "[resourceGroup().name]"
                     },
-                    "AdminPassword": {
-                        "value": "[parameters('AdminPassword')]"
+                    "SubnetId": {
+                        "value": "[variables('subnet1Id')]"
                     },
-                    "FortiAnalyzerAutoscaleAdminUsername": {
-                        "value": "[parameters('FortiAnalyzerAutoscaleAdminUsername')]"
-                    },
-                    "FortiAnalyzerAutoscaleAdminPassword": {
-                        "value": "[parameters('FortiAnalyzerAutoscaleAdminPassword')]"
+                    "UniqueResourceNamePrefix": {
+                        "value": "[variables('uniqueResourceNamePrefix')]"
                     }
                 }
             },
@@ -1600,11 +1573,17 @@
                     "FunctionExtensionVersion": {
                         "value": "~3"
                     },
+                    "Location": {
+                        "value": "[resourceGroup().location]"
+                    },
                     "NodeJSRuntimeVersion": {
                         "value": "~12"
                     },
                     "PackageResURL": {
                         "value": "[parameters('PackageResURL')]"
+                    },
+                    "ResourceGroupName": {
+                        "value": "[resourceGroup().name]"
                     },
                     "ServicePlanTier": {
                         "value": "[parameters('ServicePlanTier')]"
@@ -1628,302 +1607,109 @@
             ],
             "properties": {
                 "mode": "Incremental",
-                "template": {
-                    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-                    "contentVersion": "1.0.0.0",
-                    "parameters": {},
-                    "variables": {},
-                    "resources": [
-                        {
-                            "type": "Microsoft.Web/sites",
-                            "apiVersion": "2018-11-01",
-                            "name": "[variables('functionAppName')]",
-                            "location": "[variables('location')]",
-                            "kind": "functionapp",
-                            "properties": {
-                                "siteConfig": {
-                                    "appSettings": [
-                                        {
-                                            "name": "AzureWebJobsSecretStorageType",
-                                            "value": "Files"
-                                        },
-                                        {
-                                            "name": "AzureWebJobsStorage",
-                                            "value": "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('storageAccountName'), ';AccountKey=', listKeys(variables('storageAccountId'), '2019-04-01').keys[0].value)]"
-                                        },
-                                        {
-                                            "name": "[if(variables('enableAzureAppInsights'), 'APPINSIGHTS_INSTRUMENTATIONKEY', 'DEPLOYED_APPINSIGHTS')]",
-                                            "value": "[if(variables('enableAzureAppInsights'), reference('CreateFunctionApp').outputs.functionAppInsightsInstrumentationKey.value, 'false')]"
-                                        },
-                                        {
-                                            "name": "FUNCTIONS_EXTENSION_VERSION",
-                                            "value": "~3"
-                                        },
-                                        {
-                                            "name": "FUNCTIONS_WORKER_RUNTIME",
-                                            "value": "node"
-                                        },
-                                        {
-                                            "name": "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING",
-                                            "value": "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('storageAccountName'), ';AccountKey=', listKeys(variables('storageAccountId'), '2019-04-01').keys[0].value)]"
-                                        },
-                                        {
-                                            "name": "WEBSITE_CONTENTSHARE",
-                                            "value": "[toLower(variables('functionAppName'))]"
-                                        },
-                                        {
-                                            "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                                            "value": "~12"
-                                        },
-                                        {
-                                            "name": "WEBSITE_RUN_FROM_PACKAGE",
-                                            "value": "[parameters('PackageResURL')]"
-                                        },
-                                        {
-                                            "name": "AUTOSCALE_DB_ACCOUNT",
-                                            "value": "[variables('databaseAccountName')]"
-                                        },
-                                        {
-                                            "name": "AUTOSCALE_DB_NAME",
-                                            "value": "[variables('databaseName')]"
-                                        },
-                                        {
-                                            "name": "AUTOSCALE_DB_PRIMARY_KEY",
-                                            "value": "[listKeys(resourceId(subscription().subscriptionId, resourceGroup().name, 'Microsoft.DocumentDb/databaseAccounts', variables('databaseAccountName')), '2016-03-31').primaryMasterKey]"
-                                        },
-                                        {
-                                            "name": "AUTOSCALE_KEY_VAULT_NAME",
-                                            "value": "[variables('keyVaultName')]"
-                                        },
-                                        {
-                                            "name": "AZURE_STORAGE_ACCESS_KEY",
-                                            "value": "[listKeys(resourceId(subscription().subscriptionId, resourceGroup().name, 'Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2019-04-01').keys[0].value]"
-                                        },
-                                        {
-                                            "name": "AZURE_STORAGE_ACCOUNT",
-                                            "value": "[variables('storageAccountName')]"
-                                        },
-                                        {
-                                            "name": "CLIENT_ID",
-                                            "value": "[parameters('ServicePrincipalAppID')]"
-                                        },
-                                        {
-                                            "name": "CLIENT_SECRET",
-                                            "value": "[parameters('ServicePrincipalAppSecret')]"
-                                        },
-                                        {
-                                            "name": "RESOURCE_GROUP",
-                                            "value": "[variables('vNetResourceGroupName')]"
-                                        },
-                                        {
-                                            "name": "SUBSCRIPTION_ID",
-                                            "value": "[subscription().subscriptionId]"
-                                        },
-                                        {
-                                            "name": "TENANT_ID",
-                                            "value": "[subscription().tenantId]"
-                                        },
-                                        {
-                                            "name": "DEBUG_SAVE_CUSTOM_LOG",
-                                            "value": "true"
-                                        },
-                                        {
-                                            "name": "DEBUG_LOGGER_OUTPUT_QUEUE_ENABLED",
-                                            "value": "true"
-                                        },
-                                        {
-                                            "name": "DEBUG_LOGGER_TIMEZONE_OFFSET",
-                                            "value": "0"
-                                        },
-                                        {
-                                            "name": "additional-configset-name-list",
-                                            "value": ""
-                                        },
-                                        {
-                                            "name": "asset-storage-key-prefix",
-                                            "value": "assets"
-                                        },
-                                        {
-                                            "name": "asset-storage-name",
-                                            "value": "fortigate-autoscale"
-                                        },
-                                        {
-                                            "name": "autoscale-function-extend-execution",
-                                            "value": "true"
-                                        },
-                                        {
-                                            "name": "autoscale-function-max-execution-time",
-                                            "value": "600"
-                                        },
-                                        {
-                                            "name": "autoscale-handler-url",
-                                            "value": "[concat('https://', variables('functionAppName'), '.azurewebsites.net/api/fgt-as-handler')]"
-                                        },
-                                        {
-                                            "name": "byol-scaling-group-desired-capacity",
-                                            "value": "[parameters('BYOLInstanceCount')]"
-                                        },
-                                        {
-                                            "name": "byol-scaling-group-max-size",
-                                            "value": "[parameters('MaxBYOLInstanceCount')]"
-                                        },
-                                        {
-                                            "name": "byol-scaling-group-min-size",
-                                            "value": "[parameters('MinBYOLInstanceCount')]"
-                                        },
-                                        {
-                                            "name": "byol-scaling-group-name",
-                                            "value": "[variables('vmssNameBYOL')]"
-                                        },
-                                        {
-                                            "name": "custom-asset-container",
-                                            "value": "n/a"
-                                        },
-                                        {
-                                            "name": "custom-asset-directory",
-                                            "value": "n/a"
-                                        },
-                                        {
-                                            "name": "egress-traffic-route-table",
-                                            "value": "n/a"
-                                        },
-                                        {
-                                            "name": "enable-external-elb",
-                                            "value": "true"
-                                        },
-                                        {
-                                            "name": "enable-fortianalyzer-integration",
-                                            "value": "[if(variables('enableFortiAnalyzer'),'true', 'false')]"
-                                        },
-                                        {
-                                            "name": "enable-hybrid-licensing",
-                                            "value": "true"
-                                        },
-                                        {
-                                            "name": "enable-internal-elb",
-                                            "value": "false"
-                                        },
-                                        {
-                                            "name": "enable-second-nic",
-                                            "value": "true"
-                                        },
-                                        {
-                                            "name": "enable-vm-info-cache",
-                                            "value": "n/a"
-                                        },
-                                        {
-                                            "name": "faz-handler-name",
-                                            "value": "[concat(variables('autoscaleEndpointFazHandler'), '?code=', reference('CreateFunctionApp').outputs.functionKeyList.value['faz-auth-handler'])]"
-                                        },
-                                        {
-                                            "name": "faz-ip",
-                                            "value": "[if(variables('enableFortiAnalyzer'), reference('FortiAnalyzerIntegrationResources').outputs.fazPublicIp.value, 'n/a')]"
-                                        },
-                                        {
-                                            "name": "fortigate-admin-port",
-                                            "value": "[variables('natBackendPortHTTPS')]"
-                                        },
-                                        {
-                                            "name": "fortigate-autoscale-setting-saved",
-                                            "value": "n/a"
-                                        },
-                                        {
-                                            "name": "fortigate-autoscale-subnet-id-list",
-                                            "value": "n/a"
-                                        },
-                                        {
-                                            "name": "fortigate-autoscale-subnet-pairs",
-                                            "value": "n/a"
-                                        },
-                                        {
-                                            "name": "fortigate-autoscale-virtual-network-cidr",
-                                            "value": "[parameters('VnetAddressSpace')]"
-                                        },
-                                        {
-                                            "name": "fortigate-autoscale-virtual-network-id",
-                                            "value": "[variables('vnetName')]"
-                                        },
-                                        {
-                                            "name": "fortigate-external-elb-dns",
-                                            "value": "n/a"
-                                        },
-                                        {
-                                            "name": "fortigate-internal-elb-dns",
-                                            "value": "n/a"
-                                        },
-                                        {
-                                            "name": "fortigate-psk-secret",
-                                            "value": "[parameters('FortiGatePSKSecret')]"
-                                        },
-                                        {
-                                            "name": "fortigate-sync-interface",
-                                            "value": "port1"
-                                        },
-                                        {
-                                            "name": "fortigate-traffic-port",
-                                            "value": "[variables('natBackendPortHTTPS')]"
-                                        },
-                                        {
-                                            "name": "fortigate-traffic-protocol",
-                                            "value": "n/a"
-                                        },
-                                        {
-                                            "name": "heartbeat-delay-allowance",
-                                            "value": "[parameters('HeartBeatDelayAllowance')]"
-                                        },
-                                        {
-                                            "name": "heartbeat-interval",
-                                            "value": "[parameters('HeartBeatInterval')]"
-                                        },
-                                        {
-                                            "name": "heartbeat-loss-count",
-                                            "value": "[parameters('HeartBeatLossCount')]"
-                                        },
-                                        {
-                                            "name": "license-file-directory",
-                                            "value": "[variables('licenseFileDirectory')]"
-                                        },
-                                        {
-                                            "name": "payg-scaling-group-name",
-                                            "value": "[variables('vmssNamePAYG')]"
-                                        },
-                                        {
-                                            "name": "primary-election-timeout",
-                                            "value": "[parameters('PrimaryElectionTimeout')]"
-                                        },
-                                        {
-                                            "name": "primary-scaling-group-name",
-                                            "value": "[variables('vmssNamePrimary')]"
-                                        },
-                                        {
-                                            "name": "resource-tag-prefix",
-                                            "value": "[variables('uniqueResourceNamePrefix')]"
-                                        },
-                                        {
-                                            "name": "scaling-group-desired-capacity",
-                                            "value": "[parameters('PAYGInstanceCount')]"
-                                        },
-                                        {
-                                            "name": "scaling-group-max-size",
-                                            "value": "[parameters('MaxPAYGInstanceCount')]"
-                                        },
-                                        {
-                                            "name": "scaling-group-min-size",
-                                            "value": "[parameters('PAYGInstanceCount')]"
-                                        },
-                                        {
-                                            "name": "vm-info-cache-time",
-                                            "value": "n/a"
-                                        },
-                                        {
-                                            "name": "vpn-bgp-asn",
-                                            "value": "n/a"
-                                        }
-                                    ]
-                                }
-                            }
-                        }
-                    ]
+                "templateLink": {
+                    "uri": "https://raw.githubusercontent.com/fortinet/fortigate-autoscale-azure/3.3.0-dev.0/templates/linked_template.function_app.update.json"
+                },
+                "parameters": {
+                    "AdminPortNumber": {
+                        "value": "[variables('natBackendPortHTTPS')]"
+                    },
+                    "BYOLInstanceCount": {
+                        "value": "[parameters('BYOLInstanceCount')]"
+                    },
+                    "DatabaseAccountName": {
+                        "value": "[variables('databaseAccountName')]"
+                    },
+                    "DatabaseName": {
+                        "value": "[variables('databaseName')]"
+                    },
+                    "FortiAnalyzerIntegrationOptions": {
+                        "value": "[parameters('FortiAnalyzerIntegrationOptions')]"
+                    },
+                    "FortiGatePSKSecret": {
+                        "value": "[parameters('FortiGatePSKSecret')]"
+                    },
+                    "FunctionAppInsightName": {
+                        "value": "[reference('CreateFunctionApp').outputs.functionAppInsightName.value]"
+                    },
+                    "FunctionAppName": {
+                        "value": "[variables('functionAppName')]"
+                    },
+                    "FunctionAppResourceGroupName": {
+                        "value": "[resourceGroup().name]"
+                    },
+                    "FunctionNameFazAuthHandler": {
+                        "value": "[reference('CreateFunctionApp').outputs.functionNameFazAuthHandler.value]"
+                    },
+                    "FunctionNameFgtAsHandler": {
+                        "value": "[reference('CreateFunctionApp').outputs.functionNameFgtAsHandler.value]"
+                    },
+                    "HeartBeatDelayAllowance": {
+                        "value": "[parameters('HeartBeatDelayAllowance')]"
+                    },
+                    "HeartBeatInterval": {
+                        "value": "[parameters('HeartBeatInterval')]"
+                    },
+                    "HeartBeatLossCount": {
+                        "value": "[parameters('HeartBeatLossCount')]"
+                    },
+                    "KeyVaultName": {
+                        "value": "[variables('keyVaultName')]"
+                    },
+                    "LicenseFileDirectory": {
+                        "value": "[variables('licenseFileDirectory')]"
+                    },
+                    "MaxBYOLInstanceCount": {
+                        "value": "[parameters('MaxBYOLInstanceCount')]"
+                    },
+                    "MaxPAYGInstanceCount": {
+                        "value": "[parameters('MaxPAYGInstanceCount')]"
+                    },
+                    "MinBYOLInstanceCount": {
+                        "value": "[parameters('MinBYOLInstanceCount')]"
+                    },
+                    "PAYGInstanceCount": {
+                        "value": "[parameters('PAYGInstanceCount')]"
+                    },
+                    "PackageResURL": {
+                        "value": "[parameters('PackageResURL')]"
+                    },
+                    "PrimaryElectionTimeout": {
+                        "value": "[parameters('PrimaryElectionTimeout')]"
+                    },
+                    "ScaleSetNameBYOL": {
+                        "value": "[variables('vmssNameBYOL')]"
+                    },
+                    "ScaleSetNamePAYG": {
+                        "value": "[variables('vmssNamePAYG')]"
+                    },
+                    "ScaleSetNamePrimary": {
+                        "value": "[variables('vmssNamePrimary')]"
+                    },
+                    "ServicePrincipalAppID": {
+                        "value": "[parameters('ServicePrincipalAppID')]"
+                    },
+                    "ServicePrincipalAppSecret": {
+                        "value": "[parameters('ServicePrincipalAppSecret')]"
+                    },
+                    "StorageAccountName": {
+                        "value": "[variables('storageAccountName')]"
+                    },
+                    "TrafficPortNumber": {
+                        "value": "[variables('natBackendPortHTTPS')]"
+                    },
+                    "UniqueResourceNamePrefix": {
+                        "value": "[variables('uniqueResourceNamePrefix')]"
+                    },
+                    "VnetAddressSpace": {
+                        "value": "[parameters('VnetAddressSpace')]"
+                    },
+                    "VnetName": {
+                        "value": "[variables('vNetName')]"
+                    },
+                    "VnetResourceGroupName": {
+                        "value": "[variables('vNetResourceGroupName')]"
+                    }
                 }
             },
             "subscriptionId": "[subscription().subscriptionId]",
@@ -1940,11 +1726,11 @@
                     "uri": "https://raw.githubusercontent.com/fortinet/fortigate-autoscale-azure/3.3.0-dev.0/templates/linked_template.vmss.json"
                 },
                 "parameters": {
-                    "AdminUsername": {
-                        "value": "[parameters('AdminUsername')]"
-                    },
                     "AdminPassword": {
                         "value": "[parameters('AdminPassword')]"
+                    },
+                    "AdminUsername": {
+                        "value": "[parameters('AdminUsername')]"
                     },
                     "BYOLInstanceCount": {
                         "value": "[parameters('BYOLInstanceCount')]"
@@ -1970,20 +1756,17 @@
                     "FgtVmImagePAYG": {
                         "value": "[variables('fgtvmImagePAYG')]"
                     },
-                    "FOSVersion": {
-                        "value": "[parameters('FOSVersion')]"
-                    },
-                    "FunctioinEndpointAutoscaleHandler": {
-                        "value": "[variables('autoscaleEndpointFgtAsHandler')]"
-                    },
-                    "FunctioinEndpointByolLicense": {
-                        "value": "[variables('autoscaleEndpointByolLicense')]"
-                    },
                     "FunctionAppName": {
                         "value": "[variables('functionAppName')]"
                     },
                     "FunctionAppResourceGroupName": {
                         "value": "[resourceGroup().name]"
+                    },
+                    "FunctionNameFgtAsHandler": {
+                        "value": "[reference('CreateFunctionApp').outputs.functionNameFgtAsHandler.value]"
+                    },
+                    "FunctionNameLicenseHandler": {
+                        "value": "[reference('CreateFunctionApp').outputs.functionNameLicenseHandler.value]"
                     },
                     "InstanceType": {
                         "value": "[parameters('InstanceType')]"
@@ -2006,6 +1789,9 @@
                     "LoadBalancerBackendIPPoolNameSubnet4": {
                         "value": "[variables('loadBalancerBackendIPPoolNameSubnet4')]"
                     },
+                    "Location": {
+                        "value": "[variables('vNetResourceGroupName')]"
+                    },
                     "MaxBYOLInstanceCount": {
                         "value": "[parameters('MaxBYOLInstanceCount')]"
                     },
@@ -2020,6 +1806,9 @@
                     },
                     "PAYGInstanceCount": {
                         "value": "[parameters('PAYGInstanceCount')]"
+                    },
+                    "ResourceGroupName": {
+                        "value": "[variables('vNetResourceGroupName')]"
                     },
                     "ResourceNamePrefix": {
                         "value": "[parameters('ResourceNamePrefix')]"
@@ -2048,11 +1837,14 @@
                     "UniqueResourceNamePrefix": {
                         "value": "[variables('uniqueResourceNamePrefix')]"
                     },
+                    "VmssNameBYOL": {
+                        "value": "[variables('vmssNameBYOL')]"
+                    },
+                    "VmssNamePAYG": {
+                        "value": "[variables('vmssNamePAYG')]"
+                    },
                     "VnetName": {
                         "value": "[variables('vNetName')]"
-                    },
-                    "VnetResourceGroupName": {
-                        "value": "[variables('vNetResourceGroupName')]"
                     }
                 }
             },
@@ -2085,13 +1877,21 @@
             "type": "String",
             "value": "[reference('CreateVirtualMachineScaleSet').outputs.byolScaleSetName.value]"
         },
-        "cmdDeleteAutoscale": {
+        "cmdDeleteAll": {
             "type": "String",
-            "value": "[variables('cmdDeleteAutoscaleAll')]"
+            "value": "[concat('az account set -s ', subscription().subscriptionId, ';', variables('cmdDeleteAutoscaleAll'), if(variables('enableFortiAnalyzer'), reference('FortiAnalyzerIntegrationResources').outputs.cmdDeleteAll.value, ''), reference('CreateVirtualMachineScaleSet').outputs.cmdDeleteAll.value, variables('cmdDeleteAutoscaleAll'), variables('cmdDeleteVNetAll'))]"
         },
-        "cmdDeleteAutoscaleSettings": {
+        "cmdDeleteAutoscaleComponents": {
             "type": "String",
-            "value": "[reference('CreateVirtualMachineScaleSet').outputs.cmdDeleteAutoscaleSettings.value]"
+            "value": "[concat(variables('cmdDeleteAutoscaleAll'), if(variables('enableFortiAnalyzer'), reference('FortiAnalyzerIntegrationResources').outputs.cmdDeleteAll.value, ''))]"
+        },
+        "cmdDeleteVMSSComponents": {
+            "type": "String",
+            "value": "[reference('CreateVirtualMachineScaleSet').outputs.cmdDeleteAll.value]"
+        },
+        "cmdDeleteVNetComponents": {
+            "type": "String",
+            "value": "[variables('cmdDeleteVNetAll')]"
         },
         "deploymentPackageVersion": {
             "type": "string",

--- a/templates/deploy_fortigate_autoscale.hybrid_licensing.json
+++ b/templates/deploy_fortigate_autoscale.hybrid_licensing.json
@@ -1601,7 +1601,7 @@
             "properties": {
                 "mode": "Incremental",
                 "templateLink": {
-                    "uri": "https://raw.githubusercontent.com/fortinet/fortigate-autoscale-azure/3.3.0-dev.0/templates/linked_template.function_app.update.json"
+                    "uri": "https://raw.githubusercontent.com/fortinet/fortigate-autoscale-azure/3.3.0-dev.0/templates/linked_template.function_app.setup.json"
                 },
                 "parameters": {
                     "AdminPortNumber": {

--- a/templates/deploy_fortigate_autoscale.hybrid_licensing.params.json
+++ b/templates/deploy_fortigate_autoscale.hybrid_licensing.params.json
@@ -2,46 +2,40 @@
     "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
     "contentVersion": "3.3.0.0",
     "parameters": {
-        "ResourceNamePrefix": {
+        "AccessRestrictionIPRange": {
             "value": ""
         },
-        "VnetDeploymentMethod": {
-            "value": "create new"
-        },
-        "VnetResourceGroupName": {
+        "AdminPassword": {
             "value": ""
         },
-        "VnetName": {
+        "AdminUsername": {
+            "value": "azureadmin"
+        },
+        "BYOLInstanceCount": {
+            "value": 2
+        },
+        "FortiAnalyzerAutoscaleAdminPassword": {
             "value": ""
         },
-        "VnetAddressSpace": {
-            "value": "10.0.0.0/16"
-        },
-        "Subnet1Name": {
+        "FortiAnalyzerAutoscaleAdminUsername": {
             "value": ""
         },
-        "Subnet1AddressRange": {
-            "value": "10.0.0.0/24"
-        },
-        "Subnet2Name": {
+        "FortiAnalyzerCustomPrivateIpAddress": {
             "value": ""
         },
-        "Subnet2AddressRange": {
-            "value": "10.0.1.0/24"
+        "FortiAnalyzerInstanceType": {
+            "value": "Standard_D2"
         },
-        "Subnet3Name": {
+        "FortiAnalyzerIntegrationOptions": {
+            "value": "yes"
+        },
+        "FortiAnalyzerVersion": {
             "value": ""
         },
-        "Subnet3AddressRange": {
-            "value": "10.0.2.0/24"
-        },
-        "Subnet4Name": {
+        "FortiGatePSKSecret": {
             "value": ""
         },
-        "Subnet4AddressRange": {
-            "value": "10.0.3.0/24"
-        },
-        "NetworkSecurityGroupName": {
+        "FosVersion": {
             "value": ""
         },
         "FrontendIPDeploymentMethod": {
@@ -50,65 +44,8 @@
         "FrontendIPName": {
             "value": ""
         },
-        "LoadBalancerIP": {
-            "value": "10"
-        },
-        "InstanceType": {
-            "value": "Standard_F4"
-        },
-        "FOSVersion": {
-            "value": "6.4.5"
-        },
-        "FortiGatePSKSecret": {
-            "value": ""
-        },
-        "AdminUsername": {
-            "value": "azureadmin"
-        },
-        "AdminPassword": {
-            "value": ""
-        },
-        "AccessRestrictionIPRange": {
-            "value": ""
-        },
-        "StorageAccountType": {
-            "value": "Standard_LRS"
-        },
-        "ServicePrincipalObjectID": {
-            "value": ""
-        },
-        "ServicePrincipalAppID": {
-            "value": ""
-        },
-        "ServicePrincipalAppSecret": {
-            "value": ""
-        },
-        "BYOLInstanceCount": {
-            "value": 2
-        },
-        "MinBYOLInstanceCount": {
-            "value": 2
-        },
-        "MaxBYOLInstanceCount": {
-            "value": 2
-        },
-        "PAYGInstanceCount": {
-            "value": 0
-        },
-        "MinPAYGInstanceCount": {
-            "value": 0
-        },
-        "MaxPAYGInstanceCount": {
-            "value": 6
-        },
-        "ScaleOutThreshold": {
-            "value": 80
-        },
-        "ScaleInThreshold": {
-            "value": 20
-        },
-        "PrimaryElectionTimeout": {
-            "value": 90
+        "HeartBeatDelayAllowance": {
+            "value": 30
         },
         "HeartBeatInterval": {
             "value": 60
@@ -116,28 +53,94 @@
         "HeartBeatLossCount": {
             "value": 3
         },
-        "HeartBeatDelayAllowance": {
-            "value": 30
+        "InstanceType": {
+            "value": "Standard_F4"
+        },
+        "LoadBalancerIP": {
+            "value": "10"
+        },
+        "MaxBYOLInstanceCount": {
+            "value": 2
+        },
+        "MaxPAYGInstanceCount": {
+            "value": 6
+        },
+        "MinBYOLInstanceCount": {
+            "value": 2
+        },
+        "MinPAYGInstanceCount": {
+            "value": 0
+        },
+        "NetworkSecurityGroupName": {
+            "value": ""
+        },
+        "PAYGInstanceCount": {
+            "value": 0
         },
         "PackageResURL": {
             "value": ""
         },
-        "FortiAnalyzerIntegrationOptions": {
-            "value": "yes"
+        "PrimaryElectionTimeout": {
+            "value": 90
         },
-        "FortiAnalyzerInstanceType": {
-            "value": "Standard_D2"
-        },
-        "FortiAnalyzerVersion": {
-            "value": "6.4.4"
-        },
-        "FortiAnalyzerCustomPrivateIpAddress": {
+        "ResourceNamePrefix": {
             "value": ""
         },
-        "FortiAnalyzerAutoscaleAdminUsername": {
+        "ScaleInThreshold": {
+            "value": 20
+        },
+        "ScaleOutThreshold": {
+            "value": 80
+        },
+        "ServicePlanTier": {
+            "value": "Premium (P1V2)"
+        },
+        "ServicePrincipalAppID": {
             "value": ""
         },
-        "FortiAnalyzerAutoscaleAdminPassword": {
+        "ServicePrincipalAppSecret": {
+            "value": ""
+        },
+        "ServicePrincipalObjectID": {
+            "value": ""
+        },
+        "StorageAccountType": {
+            "value": "Standard_LRS"
+        },
+        "Subnet1AddressRange": {
+            "value": "10.0.0.0/24"
+        },
+        "Subnet1Name": {
+            "value": ""
+        },
+        "Subnet2AddressRange": {
+            "value": "10.0.1.0/24"
+        },
+        "Subnet2Name": {
+            "value": ""
+        },
+        "Subnet3AddressRange": {
+            "value": "10.0.2.0/24"
+        },
+        "Subnet3Name": {
+            "value": ""
+        },
+        "Subnet4AddressRange": {
+            "value": "10.0.3.0/24"
+        },
+        "Subnet4Name": {
+            "value": ""
+        },
+        "VnetAddressSpace": {
+            "value": "10.0.0.0/16"
+        },
+        "VnetDeploymentMethod": {
+            "value": "create new"
+        },
+        "VnetName": {
+            "value": ""
+        },
+        "VnetResourceGroupName": {
             "value": ""
         }
     }

--- a/templates/deploy_fortigate_autoscale.hybrid_licensing.params.json
+++ b/templates/deploy_fortigate_autoscale.hybrid_licensing.params.json
@@ -6,7 +6,7 @@
             "value": ""
         },
         "VnetDeploymentMethod": {
-            "value": "create a new VNet in the Autoscale resource group"
+            "value": "create new"
         },
         "VnetResourceGroupName": {
             "value": ""

--- a/templates/linked_template.faz_integration.json
+++ b/templates/linked_template.faz_integration.json
@@ -2,79 +2,57 @@
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "3.3.0.0",
     "parameters": {
-        "UniqueResourceNamePrefix": {
-            "maxLength": 18,
-            "type": "String",
-            "metadata": {
-                "description": "The unique prefix for all applicable resource names. Can only contain uppercase letters, lowercase letters, and numbers. Maximum length is 18."
-            }
-        },
-        "SubnetId": {
-            "type": "String",
-            "metadata": {
-                "description": "The subnet of a virtual network to deploy the FortiAnalyzer."
-            }
-        },
-        "FortiAnalyzerInstanceType": {
-            "defaultValue": "Standard_DS2_v2",
-            "type": "String",
-            "metadata": {
-                "description": "Size of the FortiAnalyzer VM."
-            }
-        },
-        "FortiAnalyzerVersion": {
-            "defaultValue": "6.4.2",
-            "allowedValues": ["6.4.2", "6.2.5"],
-            "type": "String",
-            "metadata": {
-                "description": "The FortiAnalyzer version supported by Fortinet FortiGate Auto Scaling."
-            }
-        },
-        "FortiAnalyzerCustomPrivateIpAddress": {
-            "type": "string",
-            "metadata": {
-                "description": "The custom private IP address to be used by the FortiAnalyzer. Must be within the Public subnet 1 CIDR range. Required if 'FortiAnalyzer Integration' is set to 'yes'. If 'FortiAnalyzer Integration' is set to 'no', any input will be ignored."
-            }
+        "AdminPassword": {
+            "type": "SecureString"
         },
         "AdminUsername": {
-            "defaultValue": "",
-            "type": "String",
-            "metadata": {
-                "description": "FortiAnalyzer administrator username."
-            }
-        },
-        "AdminPassword": {
-            "type": "SecureString",
-            "metadata": {
-                "description": "FortiAnalyzer administrator password. This field must be between 11 and 26 characters and must include at least one uppercase letter, one lowercase letter, one digit, and one special character such as (! @ # $ %)."
-            }
-        },
-        "FortiAnalyzerAutoscaleAdminUsername": {
-            "type": "string",
-            "metadata": {
-                "description": "This FortiAnalyzer account name can include numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen (-)."
-            }
+            "type": "String"
         },
         "FortiAnalyzerAutoscaleAdminPassword": {
-            "type": "securestring",
-            "metadata": {
-                "description": "The password for the 'Autoscale admin username'. The password must conform to the FortiAnalyzer password policy and have a min length of 8 and a max length 128. If you need to enable KMS encryption, refer to the documentation."
-            }
+            "type": "securestring"
+        },
+        "FortiAnalyzerAutoscaleAdminUsername": {
+            "type": "string"
+        },
+        "FortiAnalyzerCustomPrivateIpAddress": {
+            "type": "string"
+        },
+        "FortiAnalyzerInstanceType": {
+            "type": "String"
+        },
+        "FortiAnalyzerVersion": {
+            "type": "String"
+        },
+        "Location": {
+            "type": "String"
+        },
+        "ResourceGroupName": {
+            "type": "String"
+        },
+        "SubnetId": {
+            "type": "String"
+        },
+        "UniqueResourceNamePrefix": {
+            "maxLength": 18,
+            "type": "String"
         }
     },
     "variables": {
+        "cmdDeleteAll": "[concat('az account set -s ', subscription().subscriptionId, ';', variables('cmdDeleteFazPublicIp'), variables('cmdDeleteFazNic'), variables('cmdDeleteFazVm'))]",
+        "cmdDeleteFazNic": "[concat('az network nic delete', ' -g ', parameters('ResourceGroupName'), ' -n ', variables('fazNic0Name'), ';')]",
+        "cmdDeleteFazPublicIp": "[concat('az network public-ip delete', ' -g ', parameters('ResourceGroupName'), ' -n ', variables('fazPubIpName'), ';')]",
+        "cmdDeleteFazVm": "[concat('az vm delete -y', ' -g ', parameters('ResourceGroupName'), ' -n ', variables('fazName'), ';')]",
         "fazName": "[concat(toLower(parameters('UniqueResourceNamePrefix')),'faz001')]",
         "fazNic0Name": "[concat(toLower(variables('fazName')),'-nic0')]",
         "fazPubIpId": "[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/publicIPAddresses/', variables('fazPubIpName'))]",
-        "fazPubIpName": "[concat(toLower(variables('fazName')),'-public-ip')]",
-        "location": "[resourceGroup().location]"
+        "fazPubIpName": "[concat(toLower(variables('fazName')),'-public-ip')]"
     },
     "resources": [
         {
             "type": "Microsoft.Network/publicIPAddresses",
             "apiVersion": "2020-07-01",
             "name": "[variables('fazPubIpName')]",
-            "location": "[variables('location')]",
+            "location": "[parameters('Location')]",
             "sku": {
                 "name": "Standard",
                 "tier": "Regional"
@@ -87,7 +65,7 @@
             "apiVersion": "2020-07-01",
             "type": "Microsoft.Network/networkInterfaces",
             "name": "[variables('fazNic0Name')]",
-            "location": "[variables('location')]",
+            "location": "[parameters('Location')]",
             "properties": {
                 "ipConfigurations": [
                     {
@@ -112,7 +90,7 @@
             "apiVersion": "2020-06-01",
             "type": "Microsoft.Compute/virtualMachines",
             "name": "[variables('fazName')]",
-            "location": "[variables('location')]",
+            "location": "[parameters('Location')]",
             "properties": {
                 "osProfile": {
                     "computerName": "[variables('fazName')]",
@@ -158,6 +136,10 @@
         }
     ],
     "outputs": {
+        "cmdDeleteAll": {
+            "type": "String",
+            "value": "[variables('cmdDeleteAll')]"
+        },
         "fazPublicIp": {
             "type": "String",
             "value": "[reference(resourceId('Microsoft.Network/publicIPAddresses/', variables('fazPubIpName')), '2020-07-01').IpAddress]"

--- a/templates/linked_template.faz_integration.json
+++ b/templates/linked_template.faz_integration.json
@@ -20,12 +20,6 @@
         "FortiAnalyzerInstanceType": {
             "type": "String"
         },
-        "Location": {
-            "type": "String"
-        },
-        "ResourceGroupName": {
-            "type": "String"
-        },
         "SubnetId": {
             "type": "String"
         },
@@ -39,9 +33,9 @@
     },
     "variables": {
         "cmdDeleteAll": "[concat('az account set -s ', subscription().subscriptionId, ';', variables('cmdDeleteFazPublicIp'), variables('cmdDeleteFazNic'), variables('cmdDeleteFazVm'))]",
-        "cmdDeleteFazNic": "[concat('az network nic delete', ' -g ', parameters('ResourceGroupName'), ' -n ', variables('fazNic0Name'), ';')]",
-        "cmdDeleteFazPublicIp": "[concat('az network public-ip delete', ' -g ', parameters('ResourceGroupName'), ' -n ', variables('fazPubIpName'), ';')]",
-        "cmdDeleteFazVm": "[concat('az vm delete -y', ' -g ', parameters('ResourceGroupName'), ' -n ', variables('fazName'), ';')]",
+        "cmdDeleteFazNic": "[concat('az network nic delete', ' -g ', resourceGroup().name, ' -n ', variables('fazNic0Name'), ';')]",
+        "cmdDeleteFazPublicIp": "[concat('az network public-ip delete', ' -g ', resourceGroup().name, ' -n ', variables('fazPubIpName'), ';')]",
+        "cmdDeleteFazVm": "[concat('az vm delete -y', ' -g ', resourceGroup().name, ' -n ', variables('fazName'), ';')]",
         "fazName": "[concat(toLower(parameters('UniqueResourceNamePrefix')),'faz001')]",
         "fazNic0Name": "[concat(toLower(variables('fazName')),'-nic0')]",
         "fazPubIpId": "[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Network/publicIPAddresses/', variables('fazPubIpName'))]",
@@ -52,7 +46,7 @@
             "type": "Microsoft.Network/publicIPAddresses",
             "apiVersion": "2020-07-01",
             "name": "[variables('fazPubIpName')]",
-            "location": "[parameters('Location')]",
+            "location": "[resourceGroup().location]",
             "sku": {
                 "name": "Standard",
                 "tier": "Regional"
@@ -65,7 +59,7 @@
             "apiVersion": "2020-07-01",
             "type": "Microsoft.Network/networkInterfaces",
             "name": "[variables('fazNic0Name')]",
-            "location": "[parameters('Location')]",
+            "location": "[resourceGroup().location]",
             "properties": {
                 "ipConfigurations": [
                     {
@@ -90,7 +84,7 @@
             "apiVersion": "2020-06-01",
             "type": "Microsoft.Compute/virtualMachines",
             "name": "[variables('fazName')]",
-            "location": "[parameters('Location')]",
+            "location": "[resourceGroup().location]",
             "properties": {
                 "osProfile": {
                     "computerName": "[variables('fazName')]",

--- a/templates/linked_template.faz_integration.json
+++ b/templates/linked_template.faz_integration.json
@@ -20,9 +20,6 @@
         "FortiAnalyzerInstanceType": {
             "type": "String"
         },
-        "FortiAnalyzerVersion": {
-            "type": "String"
-        },
         "Location": {
             "type": "String"
         },
@@ -35,6 +32,9 @@
         "UniqueResourceNamePrefix": {
             "maxLength": 18,
             "type": "String"
+        },
+        "VmImgReferenceFaz": {
+            "type": "Object"
         }
     },
     "variables": {
@@ -103,10 +103,10 @@
                 },
                 "storageProfile": {
                     "imageReference": {
-                        "publisher": "fortinet",
-                        "offer": "fortinet-fortianalyzer",
-                        "sku": "fortinet-fortianalyzer",
-                        "version": "[parameters('FortiAnalyzerVersion')]"
+                        "publisher": "[parameters('VmImgReferenceFaz').publisher]",
+                        "offer": "[parameters('VmImgReferenceFaz').offer]",
+                        "sku": "[parameters('VmImgReferenceFaz').sku]",
+                        "version": "[parameters('VmImgReferenceFaz').version]"
                     },
                     "osDisk": {
                         "createOption": "FromImage"

--- a/templates/linked_template.function_app.json
+++ b/templates/linked_template.function_app.json
@@ -9,17 +9,11 @@
             "type": "String",
             "defaultValue": "~3"
         },
-        "Location": {
-            "type": "String"
-        },
         "NodeJSRuntimeVersion": {
             "type": "String",
             "defaultValue": "~12"
         },
         "PackageResURL": {
-            "type": "String"
-        },
-        "ResourceGroupName": {
             "type": "String"
         },
         "ServicePlanTier": {
@@ -33,10 +27,10 @@
     },
     "variables": {
         "cmdDeleteAll": "[concat('az account set -s ', subscription().subscriptionId, ';', variables('cmdDeleteInsights'), variables('cmdDeleteSite'), variables('cmdDeleteServerFarm'))]",
-        "cmdDeleteInsights": "[if(variables('enableAzureAppInsights'), concat('az monitor app-insights component delete', ' -a ', parameters('FunctionAppName'), ' -g ', parameters('ResourceGroupName'), ';'), '')]",
-        "cmdDeleteServerFarm": "[concat('az appservice plan delete -y', ' -n ', variables('hostingPlanName'), ' -g ', parameters('ResourceGroupName'), ';')]",
-        "cmdDeleteSite": "[concat('az webapp delete -y', ' -n ', parameters('FunctionAppName'), ' -g ', parameters('ResourceGroupName'), ';')]",
-        "enableAzureAppInsights": "[contains(variables('functionAppInsightAvailableLocations'), parameters('Location'))]",
+        "cmdDeleteInsights": "[if(variables('enableAzureAppInsights'), concat('az monitor app-insights component delete', ' -a ', parameters('FunctionAppName'), ' -g ', resourceGroup().name, ';'), '')]",
+        "cmdDeleteServerFarm": "[concat('az appservice plan delete -y', ' -n ', variables('hostingPlanName'), ' -g ', resourceGroup().name, ';')]",
+        "cmdDeleteSite": "[concat('az webapp delete -y', ' -n ', parameters('FunctionAppName'), ' -g ', resourceGroup().name, ';')]",
+        "enableAzureAppInsights": "[contains(variables('functionAppInsightAvailableLocations'), resourceGroup().location)]",
         "functionAppInsightAvailableLocations": [
             "australiaeast",
             "australiasoutheast",
@@ -81,14 +75,14 @@
                 "reserved": false
             }
         },
-        "storageAccountId": "[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', parameters('ResourceGroupName'), '/providers/Microsoft.Storage/storageAccounts/', parameters('StorageAccountName'))]"
+        "storageAccountId": "[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Storage/storageAccounts/', parameters('StorageAccountName'))]"
     },
     "resources": [
         {
             "type": "Microsoft.Web/serverfarms",
             "apiVersion": "2018-02-01",
             "name": "[variables('hostingPlanName')]",
-            "location": "[parameters('Location')]",
+            "location": "[resourceGroup().location]",
             "sku": {
                 "Name": "[variables('servicePlanTierPresets')[parameters('ServicePlanTier')].skucode]"
             },
@@ -103,7 +97,7 @@
             "type": "Microsoft.Web/sites",
             "apiVersion": "2018-11-01",
             "name": "[parameters('FunctionAppName')]",
-            "location": "[parameters('Location')]",
+            "location": "[resourceGroup().location]",
             "kind": "functionapp",
             "dependsOn": ["[variables('hostingPlanName')]"],
             "properties": {
@@ -155,7 +149,7 @@
             "type": "Microsoft.Insights/components",
             "apiVersion": "2018-05-01-preview",
             "name": "[variables('functionAppInsightName')]",
-            "location": "[parameters('Location')]",
+            "location": "[resourceGroup().location]",
             "kind": "web",
             "properties": {
                 "Application_Type": "web",

--- a/templates/linked_template.function_app.json
+++ b/templates/linked_template.function_app.json
@@ -3,49 +3,40 @@
     "contentVersion": "3.3.0.0",
     "parameters": {
         "FunctionAppName": {
-            "type": "String",
-            "defaultValue": "",
-            "metadata": {
-                "description": "The name of the Azure Function app."
-            }
+            "type": "String"
         },
         "FunctionExtensionVersion": {
             "type": "String",
-            "defaultValue": "~3",
-            "metadata": {
-                "description": "The Azure Function extension version."
-            }
+            "defaultValue": "~3"
+        },
+        "Location": {
+            "type": "String"
         },
         "NodeJSRuntimeVersion": {
             "type": "String",
-            "defaultValue": "~12",
-            "metadata": {
-                "description": "The NodeJS runtime version used in this Azure Function."
-            }
+            "defaultValue": "~12"
         },
         "PackageResURL": {
-            "type": "String",
-            "metadata": {
-                "description": "The public URL of the function source file named 'fortigate-autoscale-azure-funcapp.zip', and can be found inside 'fortigate-autoscale-azure-template-deployment.zip'. The public URL of the deployment package zip file that contains the resource used to deploy the Function App. This URL must be accessible by Azure."
-            }
+            "type": "String"
+        },
+        "ResourceGroupName": {
+            "type": "String"
         },
         "ServicePlanTier": {
             "defaultValue": "Premium (P1V2)",
             "allowedValues": ["Premium (P1V2)", "Free (for demo only)"],
-            "type": "String",
-            "metadata": {
-                "description": "The pricing tier for the function service plan. Note: the Free plan is for trial and demo only. Do not use it in production."
-            }
+            "type": "String"
         },
         "StorageAccountName": {
-            "type": "String",
-            "metadata": {
-                "description": "The storage account name to be used in this function app."
-            }
+            "type": "String"
         }
     },
     "variables": {
-        "enableAzureAppInsights": "[contains(variables('functionAppInsightAvailableLocations'), variables('location'))]",
+        "cmdDeleteAll": "[concat('az account set -s ', subscription().subscriptionId, ';', variables('cmdDeleteInsights'), variables('cmdDeleteSite'), variables('cmdDeleteServerFarm'))]",
+        "cmdDeleteInsights": "[if(variables('enableAzureAppInsights'), concat('az monitor app-insights component delete', ' -a ', parameters('FunctionAppName'), ' -g ', parameters('ResourceGroupName'), ';'), '')]",
+        "cmdDeleteServerFarm": "[concat('az appservice plan delete -y', ' -n ', variables('hostingPlanName'), ' -g ', parameters('ResourceGroupName'), ';')]",
+        "cmdDeleteSite": "[concat('az webapp delete -y', ' -n ', parameters('FunctionAppName'), ' -g ', parameters('ResourceGroupName'), ';')]",
+        "enableAzureAppInsights": "[contains(variables('functionAppInsightAvailableLocations'), parameters('Location'))]",
         "functionAppInsightAvailableLocations": [
             "australiaeast",
             "australiasoutheast",
@@ -72,7 +63,6 @@
         ],
         "functionAppInsightName": "[concat(parameters('FunctionAppName'),'-insights')]",
         "hostingPlanName": "[concat(parameters('FunctionAppName'),'-service-plan')]",
-        "location": "[resourceGroup().location]",
         "servicePlanTierPresets": {
             "Free (for demo only)": {
                 "sku": "Free",
@@ -91,14 +81,14 @@
                 "reserved": false
             }
         },
-        "storageAccountId": "[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Storage/storageAccounts/', parameters('StorageAccountName'))]"
+        "storageAccountId": "[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', parameters('ResourceGroupName'), '/providers/Microsoft.Storage/storageAccounts/', parameters('StorageAccountName'))]"
     },
     "resources": [
         {
             "type": "Microsoft.Web/serverfarms",
             "apiVersion": "2018-02-01",
             "name": "[variables('hostingPlanName')]",
-            "location": "[variables('location')]",
+            "location": "[parameters('Location')]",
             "sku": {
                 "Name": "[variables('servicePlanTierPresets')[parameters('ServicePlanTier')].skucode]"
             },
@@ -113,7 +103,7 @@
             "type": "Microsoft.Web/sites",
             "apiVersion": "2018-11-01",
             "name": "[parameters('FunctionAppName')]",
-            "location": "[variables('location')]",
+            "location": "[parameters('Location')]",
             "kind": "functionapp",
             "dependsOn": ["[variables('hostingPlanName')]"],
             "properties": {
@@ -165,7 +155,7 @@
             "type": "Microsoft.Insights/components",
             "apiVersion": "2018-05-01-preview",
             "name": "[variables('functionAppInsightName')]",
-            "location": "[variables('location')]",
+            "location": "[parameters('Location')]",
             "kind": "web",
             "properties": {
                 "Application_Type": "web",
@@ -175,17 +165,21 @@
         }
     ],
     "outputs": {
+        "cmdDeleteAll": {
+            "type": "String",
+            "value": "[variables('cmdDeleteAll')]"
+        },
         "enableAzureAppInsights": {
             "type": "String",
             "value": "[if(variables('enableAzureAppInsights'), 'true', 'false')]"
         },
-        "functionAppInsightId": {
-            "type": "String",
-            "value": "[if(variables('enableAzureAppInsights'), resourceId('Microsoft.Insights/components', variables('functionAppInsightName')), '')]"
-        },
         "functionAppId": {
             "type": "String",
             "value": "[resourceId('Microsoft.Web/sites', parameters('FunctionAppName'))]"
+        },
+        "functionAppInsightName": {
+            "type": "String",
+            "value": "[if(variables('enableAzureAppInsights'), variables('functionAppInsightName'), '')]"
         },
         "functionAppName": {
             "type": "String",
@@ -195,17 +189,17 @@
             "type": "String",
             "value": "[reference(resourceId('Microsoft.Web/sites', parameters('FunctionAppName')), '2016-08-01').possibleOutboundIpAddresses]"
         },
-        "functionAppInsightsInstrumentationKey": {
+        "functionNameFazAuthHandler": {
             "type": "String",
-            "value": "[if(variables('enableAzureAppInsights'), reference(resourceId('Microsoft.Insights/components', variables('functionAppInsightName')), '2018-05-01-preview').InstrumentationKey, '')]"
+            "value": "faz-auth-handler"
         },
-        "functionKeyList": {
-            "type": "secureObject",
-            "value": {
-                "byol-license": "[listKeys(resourceId(subscription().subscriptionId, resourceGroup().name, 'Microsoft.Web/sites/functions', parameters('FunctionAppName'),  'byol-license'), '2019-08-01').default]",
-                "fgt-as-handler": "[listKeys(resourceId(subscription().subscriptionId, resourceGroup().name, 'Microsoft.Web/sites/functions', parameters('FunctionAppName'),  'fgt-as-handler'), '2019-08-01').default]",
-                "faz-auth-handler": "[listKeys(resourceId(subscription().subscriptionId, resourceGroup().name, 'Microsoft.Web/sites/functions', parameters('FunctionAppName'),  'faz-auth-handler'), '2019-08-01').default]"
-            }
+        "functionNameFgtAsHandler": {
+            "type": "String",
+            "value": "fgt-as-handler"
+        },
+        "functionNameLicenseHandler": {
+            "type": "String",
+            "value": "byol-license"
         }
     }
 }

--- a/templates/linked_template.function_app.setup.json
+++ b/templates/linked_template.function_app.setup.json
@@ -1,0 +1,236 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "3.3.0.0",
+    "parameters": {
+        "AdminPortNumber": {
+            "type": "Int"
+        },
+        "BYOLInstanceCount": {
+            "type": "Int"
+        },
+        "DatabaseAccountName": {
+            "type": "String"
+        },
+        "DatabaseName": {
+            "type": "String"
+        },
+        "FortiAnalyzerIntegrationOptions": {
+            "type": "String",
+            "allowedValues": ["yes", "no"]
+        },
+        "FortiAnalyzerPublicIp": {
+            "type": "string"
+        },
+        "FortiGatePSKSecret": {
+            "type": "securestring"
+        },
+        "FunctionAppInsightName": {
+            "type": "String"
+        },
+        "FunctionAppName": {
+            "type": "String"
+        },
+        "FunctionAppResourceGroupName": {
+            "type": "String"
+        },
+        "FunctionNameFazAuthHandler": {
+            "type": "String"
+        },
+        "FunctionNameFgtAsHandler": {
+            "type": "String"
+        },
+        "HeartBeatDelayAllowance": {
+            "type": "Int"
+        },
+        "HeartBeatInterval": {
+            "type": "Int"
+        },
+        "HeartBeatLossCount": {
+            "type": "Int"
+        },
+        "KeyVaultName": {
+            "type": "String"
+        },
+        "LicenseFileDirectory": {
+            "type": "String"
+        },
+        "MaxBYOLInstanceCount": {
+            "type": "Int"
+        },
+        "MaxPAYGInstanceCount": {
+            "type": "Int"
+        },
+        "MinBYOLInstanceCount": {
+            "type": "Int"
+        },
+        "PAYGInstanceCount": {
+            "type": "Int"
+        },
+        "PackageResURL": {
+            "type": "String"
+        },
+        "PrimaryElectionTimeout": {
+            "type": "Int"
+        },
+        "ScaleSetNameBYOL": {
+            "type": "String"
+        },
+        "ScaleSetNamePAYG": {
+            "type": "String"
+        },
+        "ScaleSetNamePrimary": {
+            "type": "String"
+        },
+        "ServicePrincipalAppID": {
+            "type": "String"
+        },
+        "ServicePrincipalAppSecret": {
+            "type": "String"
+        },
+        "StorageAccountName": {
+            "type": "String"
+        },
+        "TrafficPortNumber": {
+            "type": "Int"
+        },
+        "UniqueResourceNamePrefix": {
+            "type": "String"
+        },
+        "VnetAddressSpace": {
+            "type": "String"
+        },
+        "VnetName": {
+            "type": "String"
+        },
+        "VnetResourceGroupName": {
+            "type": "String"
+        }
+    },
+    "variables": {},
+    "resources": [
+        {
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2018-05-01",
+            "name": "UpdateFunctionApp",
+            "properties": {
+                "mode": "Incremental",
+                "templateLink": {
+                    "uri": "https://raw.githubusercontent.com/fortinet/fortigate-autoscale-azure/3.3.0-dev.0/templates/linked_template.function_app.update.json"
+                },
+                "parameters": {
+                    "AdminPortNumber": {
+                        "value": "[parameters('AdminPortNumber')]"
+                    },
+                    "BYOLInstanceCount": {
+                        "value": "[parameters('BYOLInstanceCount')]"
+                    },
+                    "DatabaseAccountName": {
+                        "value": "[parameters('DatabaseAccountName')]"
+                    },
+                    "DatabaseAccountPrimaryMasterKey": {
+                        "value": "[listKeys(resourceId(subscription().subscriptionId, resourceGroup().name, 'Microsoft.DocumentDb/databaseAccounts', parameters('DatabaseAccountName')), '2016-03-31').primaryMasterKey]"
+                    },
+                    "DatabaseName": {
+                        "value": "[parameters('DatabaseName')]"
+                    },
+                    "FortiAnalyzerIntegrationOptions": {
+                        "value": "[parameters('FortiAnalyzerIntegrationOptions')]"
+                    },
+                    "FortiAnalyzerPublicIp": {
+                        "value": "[parameters('FortiAnalyzerPublicIp')]"
+                    },
+                    "FortiGatePSKSecret": {
+                        "value": "[parameters('FortiGatePSKSecret')]"
+                    },
+                    "FunctionAppInsightName": {
+                        "value": "[parameters('FunctionAppInsightName')]"
+                    },
+                    "FunctionAppName": {
+                        "value": "[parameters('FunctionAppName')]"
+                    },
+                    "FunctionKeyFazAuthHandler": {
+                        "value": "[listKeys(resourceId(subscription().subscriptionId, parameters('FunctionAppResourceGroupName'), 'Microsoft.Web/sites/functions', parameters('FunctionAppName'),  parameters('FunctionNameFazAuthHandler')), '2019-08-01').default]"
+                    },
+                    "FunctionNameFazAuthHandler": {
+                        "value": "[parameters('FunctionNameFazAuthHandler')]"
+                    },
+                    "FunctionNameFgtAsHandler": {
+                        "value": "[parameters('FunctionNameFgtAsHandler')]"
+                    },
+                    "HeartBeatDelayAllowance": {
+                        "value": "[parameters('HeartBeatDelayAllowance')]"
+                    },
+                    "HeartBeatInterval": {
+                        "value": "[parameters('HeartBeatInterval')]"
+                    },
+                    "HeartBeatLossCount": {
+                        "value": "[parameters('HeartBeatLossCount')]"
+                    },
+                    "KeyVaultName": {
+                        "value": "[parameters('KeyVaultName')]"
+                    },
+                    "LicenseFileDirectory": {
+                        "value": "[parameters('LicenseFileDirectory')]"
+                    },
+                    "MaxBYOLInstanceCount": {
+                        "value": "[parameters('MaxBYOLInstanceCount')]"
+                    },
+                    "MaxPAYGInstanceCount": {
+                        "value": "[parameters('MaxPAYGInstanceCount')]"
+                    },
+                    "MinBYOLInstanceCount": {
+                        "value": "[parameters('MinBYOLInstanceCount')]"
+                    },
+                    "PAYGInstanceCount": {
+                        "value": "[parameters('PAYGInstanceCount')]"
+                    },
+                    "PackageResURL": {
+                        "value": "[parameters('PackageResURL')]"
+                    },
+                    "PrimaryElectionTimeout": {
+                        "value": "[parameters('PrimaryElectionTimeout')]"
+                    },
+                    "ScaleSetNameBYOL": {
+                        "value": "[parameters('ScaleSetNameBYOL')]"
+                    },
+                    "ScaleSetNamePAYG": {
+                        "value": "[parameters('ScaleSetNamePAYG')]"
+                    },
+                    "ScaleSetNamePrimary": {
+                        "value": "[parameters('ScaleSetNamePrimary')]"
+                    },
+                    "ServicePrincipalAppID": {
+                        "value": "[parameters('ServicePrincipalAppID')]"
+                    },
+                    "ServicePrincipalAppSecret": {
+                        "value": "[parameters('ServicePrincipalAppSecret')]"
+                    },
+                    "StorageAccountKey": {
+                        "value": "[listKeys(resourceId(subscription().subscriptionId, resourceGroup().name, 'Microsoft.Storage/storageAccounts', parameters('StorageAccountName')), '2019-04-01').keys[0].value]"
+                    },
+                    "StorageAccountName": {
+                        "value": "[parameters('StorageAccountName')]"
+                    },
+                    "TrafficPortNumber": {
+                        "value": "[parameters('TrafficPortNumber')]"
+                    },
+                    "UniqueResourceNamePrefix": {
+                        "value": "[parameters('UniqueResourceNamePrefix')]"
+                    },
+                    "VnetAddressSpace": {
+                        "value": "[parameters('VnetAddressSpace')]"
+                    },
+                    "VnetName": {
+                        "value": "[parameters('VnetName')]"
+                    },
+                    "VnetResourceGroupName": {
+                        "value": "[parameters('VnetResourceGroupName')]"
+                    }
+                }
+            },
+            "subscriptionId": "[subscription().subscriptionId]",
+            "resourceGroup": "[resourceGroup().name]"
+        }
+    ],
+    "outputs": {}
+}

--- a/templates/linked_template.function_app.update.json
+++ b/templates/linked_template.function_app.update.json
@@ -1,0 +1,409 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "3.3.0.0",
+    "parameters": {
+        "AdminPortNumber": {
+            "type": "Int"
+        },
+        "BYOLInstanceCount": {
+            "type": "Int"
+        },
+        "DatabaseAccountName": {
+            "type": "String"
+        },
+        "DatabaseName": {
+            "type": "String"
+        },
+        "FortiAnalyzerIntegrationOptions": {
+            "type": "String",
+            "allowedValues": ["yes", "no"]
+        },
+        "FortiGatePSKSecret": {
+            "type": "securestring"
+        },
+        "FunctionAppInsightName": {
+            "type": "String"
+        },
+        "FunctionAppName": {
+            "type": "String"
+        },
+        "FunctionAppResourceGroupName": {
+            "type": "String"
+        },
+        "FunctionNameFazAuthHandler": {
+            "type": "String"
+        },
+        "FunctionNameFgtAsHandler": {
+            "type": "String"
+        },
+        "HeartBeatDelayAllowance": {
+            "type": "Int"
+        },
+        "HeartBeatInterval": {
+            "type": "Int"
+        },
+        "HeartBeatLossCount": {
+            "type": "Int"
+        },
+        "KeyVaultName": {
+            "type": "String"
+        },
+        "LicenseFileDirectory": {
+            "type": "String"
+        },
+        "Location": {
+            "type": "String"
+        },
+        "MaxBYOLInstanceCount": {
+            "type": "Int"
+        },
+        "MaxPAYGInstanceCount": {
+            "type": "Int"
+        },
+        "MinBYOLInstanceCount": {
+            "type": "Int"
+        },
+        "PAYGInstanceCount": {
+            "type": "Int"
+        },
+        "PackageResURL": {
+            "type": "String"
+        },
+        "PrimaryElectionTimeout": {
+            "type": "Int"
+        },
+        "ResourceGroupName": {
+            "type": "String"
+        },
+        "ScaleSetNameBYOL": {
+            "type": "String"
+        },
+        "ScaleSetNamePAYG": {
+            "type": "String"
+        },
+        "ScaleSetNamePrimary": {
+            "type": "String"
+        },
+        "ServicePrincipalAppID": {
+            "type": "String"
+        },
+        "ServicePrincipalAppSecret": {
+            "type": "String"
+        },
+        "StorageAccountName": {
+            "type": "String"
+        },
+        "TrafficPortNumber": {
+            "type": "Int"
+        },
+        "UniqueResourceNamePrefix": {
+            "type": "String"
+        },
+        "VnetAddressSpace": {
+            "type": "String"
+        },
+        "VnetName": {
+            "type": "String"
+        },
+        "VnetResourceGroupName": {
+            "type": "String"
+        }
+    },
+    "variables": {
+        "funcappURL": "[concat('https://', parameters('FunctionAppName'), '.azurewebsites.net')]",
+        "enableFortiAnalyzer": "[equals(parameters('FortiAnalyzerIntegrationOptions'), 'yes')]",
+        "storageAccountId": "[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', parameters('ResourceGroupName'), '/providers/Microsoft.Storage/storageAccounts/', parameters('StorageAccountName'))]"
+    },
+    "resources": [
+        {
+            "type": "Microsoft.Web/sites",
+            "apiVersion": "2018-11-01",
+            "name": "[parameters('FunctionAppName')]",
+            "location": "[parameters('Location')]",
+            "kind": "functionapp",
+            "properties": {
+                "siteConfig": {
+                    "appSettings": [
+                        {
+                            "name": "AzureWebJobsSecretStorageType",
+                            "value": "Files"
+                        },
+                        {
+                            "name": "AzureWebJobsStorage",
+                            "value": "[concat('DefaultEndpointsProtocol=https;AccountName=', parameters('StorageAccountName'), ';AccountKey=', listKeys(variables('storageAccountId'), '2019-04-01').keys[0].value)]"
+                        },
+                        {
+                            "name": "[if(not(empty(parameters('FunctionAppInsightName'))), 'APPINSIGHTS_INSTRUMENTATIONKEY', 'DEPLOYED_APPINSIGHTS')]",
+                            "value": "[if(not(empty(parameters('FunctionAppInsightName'))), resourceId('Microsoft.Insights/components', parameters('FunctionAppInsightName')), 'false')]"
+                        },
+                        {
+                            "name": "FUNCTIONS_EXTENSION_VERSION",
+                            "value": "~3"
+                        },
+                        {
+                            "name": "FUNCTIONS_WORKER_RUNTIME",
+                            "value": "node"
+                        },
+                        {
+                            "name": "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING",
+                            "value": "[concat('DefaultEndpointsProtocol=https;AccountName=', parameters('StorageAccountName'), ';AccountKey=', listKeys(variables('storageAccountId'), '2019-04-01').keys[0].value)]"
+                        },
+                        {
+                            "name": "WEBSITE_CONTENTSHARE",
+                            "value": "[toLower(parameters('FunctionAppName'))]"
+                        },
+                        {
+                            "name": "WEBSITE_NODE_DEFAULT_VERSION",
+                            "value": "~12"
+                        },
+                        {
+                            "name": "WEBSITE_RUN_FROM_PACKAGE",
+                            "value": "[parameters('PackageResURL')]"
+                        },
+                        {
+                            "name": "AUTOSCALE_DB_ACCOUNT",
+                            "value": "[parameters('DatabaseAccountName')]"
+                        },
+                        {
+                            "name": "AUTOSCALE_DB_NAME",
+                            "value": "[parameters('DatabaseName')]"
+                        },
+                        {
+                            "name": "AUTOSCALE_DB_PRIMARY_KEY",
+                            "value": "[listKeys(resourceId(subscription().subscriptionId, parameters('ResourceGroupName'), 'Microsoft.DocumentDb/databaseAccounts', parameters('DatabaseAccountName')), '2016-03-31').primaryMasterKey]"
+                        },
+                        {
+                            "name": "AUTOSCALE_KEY_VAULT_NAME",
+                            "value": "[parameters('KeyVaultName')]"
+                        },
+                        {
+                            "name": "AZURE_STORAGE_ACCESS_KEY",
+                            "value": "[listKeys(resourceId(subscription().subscriptionId, parameters('ResourceGroupName'), 'Microsoft.Storage/storageAccounts', parameters('StorageAccountName')), '2019-04-01').keys[0].value]"
+                        },
+                        {
+                            "name": "AZURE_STORAGE_ACCOUNT",
+                            "value": "[parameters('StorageAccountName')]"
+                        },
+                        {
+                            "name": "CLIENT_ID",
+                            "value": "[parameters('ServicePrincipalAppID')]"
+                        },
+                        {
+                            "name": "CLIENT_SECRET",
+                            "value": "[parameters('ServicePrincipalAppSecret')]"
+                        },
+                        {
+                            "name": "RESOURCE_GROUP",
+                            "value": "[parameters('VnetResourceGroupName')]"
+                        },
+                        {
+                            "name": "SUBSCRIPTION_ID",
+                            "value": "[subscription().subscriptionId]"
+                        },
+                        {
+                            "name": "TENANT_ID",
+                            "value": "[subscription().tenantId]"
+                        },
+                        {
+                            "name": "DEBUG_SAVE_CUSTOM_LOG",
+                            "value": "true"
+                        },
+                        {
+                            "name": "DEBUG_LOGGER_OUTPUT_QUEUE_ENABLED",
+                            "value": "true"
+                        },
+                        {
+                            "name": "DEBUG_LOGGER_TIMEZONE_OFFSET",
+                            "value": "0"
+                        },
+                        {
+                            "name": "additional-configset-name-list",
+                            "value": ""
+                        },
+                        {
+                            "name": "asset-storage-key-prefix",
+                            "value": "assets"
+                        },
+                        {
+                            "name": "asset-storage-name",
+                            "value": "fortigate-autoscale"
+                        },
+                        {
+                            "name": "autoscale-function-extend-execution",
+                            "value": "true"
+                        },
+                        {
+                            "name": "autoscale-function-max-execution-time",
+                            "value": "600"
+                        },
+                        {
+                            "name": "autoscale-handler-url",
+                            "value": "[concat(variables('funcappURL'), '/api/', parameters('FunctionNameFgtAsHandler'))]"
+                        },
+                        {
+                            "name": "byol-scaling-group-desired-capacity",
+                            "value": "[parameters('BYOLInstanceCount')]"
+                        },
+                        {
+                            "name": "byol-scaling-group-max-size",
+                            "value": "[parameters('MaxBYOLInstanceCount')]"
+                        },
+                        {
+                            "name": "byol-scaling-group-min-size",
+                            "value": "[parameters('MinBYOLInstanceCount')]"
+                        },
+                        {
+                            "name": "byol-scaling-group-name",
+                            "value": "[parameters('ScaleSetNameBYOL')]"
+                        },
+                        {
+                            "name": "custom-asset-container",
+                            "value": "n/a"
+                        },
+                        {
+                            "name": "custom-asset-directory",
+                            "value": "n/a"
+                        },
+                        {
+                            "name": "egress-traffic-route-table",
+                            "value": "n/a"
+                        },
+                        {
+                            "name": "enable-external-elb",
+                            "value": "true"
+                        },
+                        {
+                            "name": "enable-fortianalyzer-integration",
+                            "value": "[if(variables('enableFortiAnalyzer'),'true', 'false')]"
+                        },
+                        {
+                            "name": "enable-hybrid-licensing",
+                            "value": "true"
+                        },
+                        {
+                            "name": "enable-internal-elb",
+                            "value": "false"
+                        },
+                        {
+                            "name": "enable-second-nic",
+                            "value": "true"
+                        },
+                        {
+                            "name": "enable-vm-info-cache",
+                            "value": "n/a"
+                        },
+                        {
+                            "name": "faz-handler-name",
+                            "value": "[concat(variables('funcappURL'), '/api/', parameters('FunctionNameFazAuthHandler'),  '?code=', listKeys(resourceId(subscription().subscriptionId, parameters('FunctionAppResourceGroupName'), 'Microsoft.Web/sites/functions', parameters('FunctionAppName'),  parameters('FunctionNameFazAuthHandler')), '2019-08-01').default)]"
+                        },
+                        {
+                            "name": "faz-ip",
+                            "value": "[if(variables('enableFortiAnalyzer'), reference('FortiAnalyzerIntegrationResources').outputs.fazPublicIp.value, 'n/a')]"
+                        },
+                        {
+                            "name": "fortigate-admin-port",
+                            "value": "[parameters('AdminPortNumber')]"
+                        },
+                        {
+                            "name": "fortigate-autoscale-setting-saved",
+                            "value": "n/a"
+                        },
+                        {
+                            "name": "fortigate-autoscale-subnet-id-list",
+                            "value": "n/a"
+                        },
+                        {
+                            "name": "fortigate-autoscale-subnet-pairs",
+                            "value": "n/a"
+                        },
+                        {
+                            "name": "fortigate-autoscale-virtual-network-cidr",
+                            "value": "[parameters('VnetAddressSpace')]"
+                        },
+                        {
+                            "name": "fortigate-autoscale-virtual-network-id",
+                            "value": "[parameters('VnetName')]"
+                        },
+                        {
+                            "name": "fortigate-external-elb-dns",
+                            "value": "n/a"
+                        },
+                        {
+                            "name": "fortigate-internal-elb-dns",
+                            "value": "n/a"
+                        },
+                        {
+                            "name": "fortigate-psk-secret",
+                            "value": "[parameters('FortiGatePSKSecret')]"
+                        },
+                        {
+                            "name": "fortigate-sync-interface",
+                            "value": "port1"
+                        },
+                        {
+                            "name": "fortigate-traffic-port",
+                            "value": "[parameters('TrafficPortNumber')]"
+                        },
+                        {
+                            "name": "fortigate-traffic-protocol",
+                            "value": "n/a"
+                        },
+                        {
+                            "name": "heartbeat-delay-allowance",
+                            "value": "[parameters('HeartBeatDelayAllowance')]"
+                        },
+                        {
+                            "name": "heartbeat-interval",
+                            "value": "[parameters('HeartBeatInterval')]"
+                        },
+                        {
+                            "name": "heartbeat-loss-count",
+                            "value": "[parameters('HeartBeatLossCount')]"
+                        },
+                        {
+                            "name": "license-file-directory",
+                            "value": "[parameters('LicenseFileDirectory')]"
+                        },
+                        {
+                            "name": "payg-scaling-group-name",
+                            "value": "[parameters('ScaleSetNamePAYG')]"
+                        },
+                        {
+                            "name": "primary-election-timeout",
+                            "value": "[parameters('PrimaryElectionTimeout')]"
+                        },
+                        {
+                            "name": "primary-scaling-group-name",
+                            "value": "[parameters('ScaleSetNamePrimary')]"
+                        },
+                        {
+                            "name": "resource-tag-prefix",
+                            "value": "[parameters('UniqueResourceNamePrefix')]"
+                        },
+                        {
+                            "name": "scaling-group-desired-capacity",
+                            "value": "[parameters('PAYGInstanceCount')]"
+                        },
+                        {
+                            "name": "scaling-group-max-size",
+                            "value": "[parameters('MaxPAYGInstanceCount')]"
+                        },
+                        {
+                            "name": "scaling-group-min-size",
+                            "value": "[parameters('PAYGInstanceCount')]"
+                        },
+                        {
+                            "name": "vm-info-cache-time",
+                            "value": "n/a"
+                        },
+                        {
+                            "name": "vpn-bgp-asn",
+                            "value": "n/a"
+                        }
+                    ]
+                }
+            }
+        }
+    ],
+    "outputs": {}
+}

--- a/templates/linked_template.function_app.update.json
+++ b/templates/linked_template.function_app.update.json
@@ -18,6 +18,9 @@
             "type": "String",
             "allowedValues": ["yes", "no"]
         },
+        "FortiAnalyzerPublicIp": {
+            "type": "string"
+        },
         "FortiGatePSKSecret": {
             "type": "securestring"
         },
@@ -292,7 +295,7 @@
                         },
                         {
                             "name": "faz-ip",
-                            "value": "[if(variables('enableFortiAnalyzer'), reference('FortiAnalyzerIntegrationResources').outputs.fazPublicIp.value, 'n/a')]"
+                            "value": "[if(variables('enableFortiAnalyzer'), parameters('FortiAnalyzerPublicIp'), 'n/a')]"
                         },
                         {
                             "name": "fortigate-admin-port",

--- a/templates/linked_template.function_app.update.json
+++ b/templates/linked_template.function_app.update.json
@@ -11,6 +11,9 @@
         "DatabaseAccountName": {
             "type": "String"
         },
+        "DatabaseAccountPrimaryMasterKey": {
+            "type": "securestring"
+        },
         "DatabaseName": {
             "type": "String"
         },
@@ -30,8 +33,8 @@
         "FunctionAppName": {
             "type": "String"
         },
-        "FunctionAppResourceGroupName": {
-            "type": "String"
+        "FunctionKeyFazAuthHandler": {
+            "type": "securestring"
         },
         "FunctionNameFazAuthHandler": {
             "type": "String"
@@ -87,6 +90,9 @@
         "ServicePrincipalAppSecret": {
             "type": "String"
         },
+        "StorageAccountKey": {
+            "type": "securestring"
+        },
         "StorageAccountName": {
             "type": "String"
         },
@@ -108,8 +114,7 @@
     },
     "variables": {
         "funcappURL": "[concat('https://', parameters('FunctionAppName'), '.azurewebsites.net')]",
-        "enableFortiAnalyzer": "[equals(parameters('FortiAnalyzerIntegrationOptions'), 'yes')]",
-        "storageAccountId": "[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Storage/storageAccounts/', parameters('StorageAccountName'))]"
+        "enableFortiAnalyzer": "[equals(parameters('FortiAnalyzerIntegrationOptions'), 'yes')]"
     },
     "resources": [
         {
@@ -127,7 +132,7 @@
                         },
                         {
                             "name": "AzureWebJobsStorage",
-                            "value": "[concat('DefaultEndpointsProtocol=https;AccountName=', parameters('StorageAccountName'), ';AccountKey=', listKeys(variables('storageAccountId'), '2019-04-01').keys[0].value)]"
+                            "value": "[concat('DefaultEndpointsProtocol=https;AccountName=', parameters('StorageAccountName'), ';AccountKey=', parameters('StorageAccountKey'))]"
                         },
                         {
                             "name": "[if(not(empty(parameters('FunctionAppInsightName'))), 'APPINSIGHTS_INSTRUMENTATIONKEY', 'DEPLOYED_APPINSIGHTS')]",
@@ -143,7 +148,7 @@
                         },
                         {
                             "name": "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING",
-                            "value": "[concat('DefaultEndpointsProtocol=https;AccountName=', parameters('StorageAccountName'), ';AccountKey=', listKeys(variables('storageAccountId'), '2019-04-01').keys[0].value)]"
+                            "value": "[concat('DefaultEndpointsProtocol=https;AccountName=', parameters('StorageAccountName'), ';AccountKey=', parameters('StorageAccountKey'))]"
                         },
                         {
                             "name": "WEBSITE_CONTENTSHARE",
@@ -167,7 +172,7 @@
                         },
                         {
                             "name": "AUTOSCALE_DB_PRIMARY_KEY",
-                            "value": "[listKeys(resourceId(subscription().subscriptionId, resourceGroup().name, 'Microsoft.DocumentDb/databaseAccounts', parameters('DatabaseAccountName')), '2016-03-31').primaryMasterKey]"
+                            "value": "[parameters('DatabaseAccountPrimaryMasterKey')]"
                         },
                         {
                             "name": "AUTOSCALE_KEY_VAULT_NAME",
@@ -175,7 +180,7 @@
                         },
                         {
                             "name": "AZURE_STORAGE_ACCESS_KEY",
-                            "value": "[listKeys(resourceId(subscription().subscriptionId, resourceGroup().name, 'Microsoft.Storage/storageAccounts', parameters('StorageAccountName')), '2019-04-01').keys[0].value]"
+                            "value": "[parameters('StorageAccountKey')]"
                         },
                         {
                             "name": "AZURE_STORAGE_ACCOUNT",
@@ -291,7 +296,7 @@
                         },
                         {
                             "name": "faz-handler-name",
-                            "value": "[concat(variables('funcappURL'), '/api/', parameters('FunctionNameFazAuthHandler'),  '?code=', listKeys(resourceId(subscription().subscriptionId, parameters('FunctionAppResourceGroupName'), 'Microsoft.Web/sites/functions', parameters('FunctionAppName'),  parameters('FunctionNameFazAuthHandler')), '2019-08-01').default)]"
+                            "value": "[concat(variables('funcappURL'), '/api/', parameters('FunctionNameFazAuthHandler'),  '?code=', parameters('FunctionKeyFazAuthHandler'))]"
                         },
                         {
                             "name": "faz-ip",

--- a/templates/linked_template.function_app.update.json
+++ b/templates/linked_template.function_app.update.json
@@ -51,9 +51,6 @@
         "LicenseFileDirectory": {
             "type": "String"
         },
-        "Location": {
-            "type": "String"
-        },
         "MaxBYOLInstanceCount": {
             "type": "Int"
         },
@@ -71,9 +68,6 @@
         },
         "PrimaryElectionTimeout": {
             "type": "Int"
-        },
-        "ResourceGroupName": {
-            "type": "String"
         },
         "ScaleSetNameBYOL": {
             "type": "String"
@@ -112,14 +106,14 @@
     "variables": {
         "funcappURL": "[concat('https://', parameters('FunctionAppName'), '.azurewebsites.net')]",
         "enableFortiAnalyzer": "[equals(parameters('FortiAnalyzerIntegrationOptions'), 'yes')]",
-        "storageAccountId": "[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', parameters('ResourceGroupName'), '/providers/Microsoft.Storage/storageAccounts/', parameters('StorageAccountName'))]"
+        "storageAccountId": "[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Storage/storageAccounts/', parameters('StorageAccountName'))]"
     },
     "resources": [
         {
             "type": "Microsoft.Web/sites",
             "apiVersion": "2018-11-01",
             "name": "[parameters('FunctionAppName')]",
-            "location": "[parameters('Location')]",
+            "location": "[resourceGroup().location]",
             "kind": "functionapp",
             "properties": {
                 "siteConfig": {
@@ -170,7 +164,7 @@
                         },
                         {
                             "name": "AUTOSCALE_DB_PRIMARY_KEY",
-                            "value": "[listKeys(resourceId(subscription().subscriptionId, parameters('ResourceGroupName'), 'Microsoft.DocumentDb/databaseAccounts', parameters('DatabaseAccountName')), '2016-03-31').primaryMasterKey]"
+                            "value": "[listKeys(resourceId(subscription().subscriptionId, resourceGroup().name, 'Microsoft.DocumentDb/databaseAccounts', parameters('DatabaseAccountName')), '2016-03-31').primaryMasterKey]"
                         },
                         {
                             "name": "AUTOSCALE_KEY_VAULT_NAME",
@@ -178,7 +172,7 @@
                         },
                         {
                             "name": "AZURE_STORAGE_ACCESS_KEY",
-                            "value": "[listKeys(resourceId(subscription().subscriptionId, parameters('ResourceGroupName'), 'Microsoft.Storage/storageAccounts', parameters('StorageAccountName')), '2019-04-01').keys[0].value]"
+                            "value": "[listKeys(resourceId(subscription().subscriptionId, resourceGroup().name, 'Microsoft.Storage/storageAccounts', parameters('StorageAccountName')), '2019-04-01').keys[0].value]"
                         },
                         {
                             "name": "AZURE_STORAGE_ACCOUNT",

--- a/templates/linked_template.vmss.json
+++ b/templates/linked_template.vmss.json
@@ -63,9 +63,6 @@
         "LoadBalancerBackendIPPoolNameSubnet4": {
             "type": "String"
         },
-        "Location": {
-            "type": "String"
-        },
         "MaxBYOLInstanceCount": {
             "type": "Int"
         },
@@ -80,9 +77,6 @@
         },
         "PAYGInstanceCount": {
             "type": "Int"
-        },
-        "ResourceGroupName": {
-            "type": "String"
         },
         "ResourceNamePrefix": {
             "maxLength": 10,
@@ -138,7 +132,7 @@
                         "metricTrigger": {
                             "metricName": "Percentage CPU",
                             "metricNamespace": "",
-                            "metricResourceUri": "[concat('/subscriptions/',subscription().subscriptionId, '/resourceGroups/',  parameters('ResourceGroupName'), '/providers/Microsoft.Compute/virtualMachineScaleSets/', parameters('VmssNameBYOL'))]",
+                            "metricResourceUri": "[concat('/subscriptions/',subscription().subscriptionId, '/resourceGroups/',  resourceGroup().name, '/providers/Microsoft.Compute/virtualMachineScaleSets/', parameters('VmssNameBYOL'))]",
                             "timeGrain": "PT1M",
                             "statistic": "Average",
                             "timeWindow": "PT5M",
@@ -157,7 +151,7 @@
                         "metricTrigger": {
                             "metricName": "Percentage CPU",
                             "metricNamespace": "",
-                            "metricResourceUri": "[concat('/subscriptions/',subscription().subscriptionId, '/resourceGroups/',  parameters('ResourceGroupName'), '/providers/Microsoft.Compute/virtualMachineScaleSets/', parameters('VmssNameBYOL'))]",
+                            "metricResourceUri": "[concat('/subscriptions/',subscription().subscriptionId, '/resourceGroups/',  resourceGroup().name, '/providers/Microsoft.Compute/virtualMachineScaleSets/', parameters('VmssNameBYOL'))]",
                             "timeGrain": "PT1M",
                             "statistic": "Average",
                             "timeWindow": "PT5M",
@@ -182,7 +176,7 @@
                         "metricTrigger": {
                             "metricName": "Percentage CPU",
                             "metricNamespace": "",
-                            "metricResourceUri": "[concat('/subscriptions/',subscription().subscriptionId, '/resourceGroups/',  parameters('ResourceGroupName'), '/providers/Microsoft.Compute/virtualMachineScaleSets/', parameters('VmssNameBYOL'))]",
+                            "metricResourceUri": "[concat('/subscriptions/',subscription().subscriptionId, '/resourceGroups/',  resourceGroup().name, '/providers/Microsoft.Compute/virtualMachineScaleSets/', parameters('VmssNameBYOL'))]",
                             "timeGrain": "PT1M",
                             "statistic": "Average",
                             "timeWindow": "PT5M",
@@ -201,7 +195,7 @@
                         "metricTrigger": {
                             "metricName": "Percentage CPU",
                             "metricNamespace": "",
-                            "metricResourceUri": "[concat('/subscriptions/',subscription().subscriptionId, '/resourceGroups/',  parameters('ResourceGroupName'), '/providers/Microsoft.Compute/virtualMachineScaleSets/', parameters('VmssNamePAYG'))]",
+                            "metricResourceUri": "[concat('/subscriptions/',subscription().subscriptionId, '/resourceGroups/',  resourceGroup().name, '/providers/Microsoft.Compute/virtualMachineScaleSets/', parameters('VmssNamePAYG'))]",
                             "timeGrain": "PT1M",
                             "statistic": "Average",
                             "timeWindow": "PT5M",
@@ -220,7 +214,7 @@
                         "metricTrigger": {
                             "metricName": "Percentage CPU",
                             "metricNamespace": "",
-                            "metricResourceUri": "[concat('/subscriptions/',subscription().subscriptionId, '/resourceGroups/',  parameters('ResourceGroupName'), '/providers/Microsoft.Compute/virtualMachineScaleSets/', parameters('VmssNameBYOL'))]",
+                            "metricResourceUri": "[concat('/subscriptions/',subscription().subscriptionId, '/resourceGroups/',  resourceGroup().name, '/providers/Microsoft.Compute/virtualMachineScaleSets/', parameters('VmssNameBYOL'))]",
                             "timeGrain": "PT1M",
                             "statistic": "Average",
                             "timeWindow": "PT5M",
@@ -239,7 +233,7 @@
                         "metricTrigger": {
                             "metricName": "Percentage CPU",
                             "metricNamespace": "",
-                            "metricResourceUri": "[concat('/subscriptions/',subscription().subscriptionId, '/resourceGroups/',  parameters('ResourceGroupName'), '/providers/Microsoft.Compute/virtualMachineScaleSets/', parameters('VmssNamePAYG'))]",
+                            "metricResourceUri": "[concat('/subscriptions/',subscription().subscriptionId, '/resourceGroups/',  resourceGroup().name, '/providers/Microsoft.Compute/virtualMachineScaleSets/', parameters('VmssNamePAYG'))]",
                             "timeGrain": "PT1M",
                             "statistic": "Average",
                             "timeWindow": "PT5M",
@@ -263,7 +257,7 @@
                         "metricTrigger": {
                             "metricName": "Percentage CPU",
                             "metricNamespace": "",
-                            "metricResourceUri": "[concat('/subscriptions/',subscription().subscriptionId, '/resourceGroups/',  parameters('ResourceGroupName'), '/providers/Microsoft.Compute/virtualMachineScaleSets/', parameters('VmssNamePAYG'))]",
+                            "metricResourceUri": "[concat('/subscriptions/',subscription().subscriptionId, '/resourceGroups/',  resourceGroup().name, '/providers/Microsoft.Compute/virtualMachineScaleSets/', parameters('VmssNamePAYG'))]",
                             "timeGrain": "PT1M",
                             "statistic": "Average",
                             "timeWindow": "PT5M",
@@ -282,7 +276,7 @@
                         "metricTrigger": {
                             "metricName": "Percentage CPU",
                             "metricNamespace": "",
-                            "metricResourceUri": "[concat('/subscriptions/',subscription().subscriptionId, '/resourceGroups/',  parameters('ResourceGroupName'), '/providers/Microsoft.Compute/virtualMachineScaleSets/', parameters('VmssNamePAYG'))]",
+                            "metricResourceUri": "[concat('/subscriptions/',subscription().subscriptionId, '/resourceGroups/',  resourceGroup().name, '/providers/Microsoft.Compute/virtualMachineScaleSets/', parameters('VmssNamePAYG'))]",
                             "timeGrain": "PT1M",
                             "statistic": "Average",
                             "timeWindow": "PT5M",
@@ -301,13 +295,13 @@
             }
         },
         "cmdDeleteAll": "[concat('az account set -s ', subscription().subscriptionId, ';', variables('cmdDeleteAutoscaleSettings'), variables('cmdDeleteVMSS'))]",
-        "cmdDeleteAutoscaleSettings": "[concat('az monitor autoscale delete', ' -g ', parameters('ResourceGroupName'), ' -n ', variables('autoscaleSettingsNameBYOL'), ';', 'az monitor autoscale delete -g ', parameters('ResourceGroupName'), ' -n ', variables('autoscaleSettingsNamePAYG'), ';')]",
-        "cmdDeleteVMSS": "[concat('az vmss delete', ' -g ', parameters('ResourceGroupName'),' -n ', parameters('VmssNameBYOL'), ';', 'az vmss delete -g ', parameters('ResourceGroupName'),' -n ', parameters('VmssNamePAYG'), ';')]"
+        "cmdDeleteAutoscaleSettings": "[concat('az monitor autoscale delete', ' -g ', resourceGroup().name, ' -n ', variables('autoscaleSettingsNameBYOL'), ';', 'az monitor autoscale delete -g ', resourceGroup().name, ' -n ', variables('autoscaleSettingsNamePAYG'), ';')]",
+        "cmdDeleteVMSS": "[concat('az vmss delete', ' -g ', resourceGroup().name,' -n ', parameters('VmssNameBYOL'), ';', 'az vmss delete -g ', resourceGroup().name,' -n ', parameters('VmssNamePAYG'), ';')]"
     },
     "resources": [
         {
             "apiVersion": "2019-07-01",
-            "location": "[parameters('Location')]",
+            "location": "[resourceGroup().location]",
             "name": "[parameters('VmssNameBYOL')]",
             "plan": {
                 "name": "[parameters('VmImageReferenceFgtBYOL').sku]",
@@ -358,19 +352,19 @@
                                             "name": "[concat(parameters('VmssNameBYOL'), '-ip-config','-subnet', '1')]",
                                             "properties": {
                                                 "Subnet": {
-                                                    "id": "[resourceId(subscription().subscriptionId, parameters('ResourceGroupName'), 'Microsoft.Network/virtualNetworks/subnets', parameters('VnetName'), parameters('Subnet1Name'))]"
+                                                    "id": "[resourceId(subscription().subscriptionId, resourceGroup().name, 'Microsoft.Network/virtualNetworks/subnets', parameters('VnetName'), parameters('Subnet1Name'))]"
                                                 },
                                                 "loadBalancerBackendAddressPools": [
                                                     {
-                                                        "id": "[resourceId(subscription().subscriptionId, parameters('ResourceGroupName'), 'Microsoft.Network/loadBalancers/backendAddressPools', parameters('ExternalLoadBalancerName'), parameters('LoadBalancerBackendIPPoolNameSubnet1'))]"
+                                                        "id": "[resourceId(subscription().subscriptionId, resourceGroup().name, 'Microsoft.Network/loadBalancers/backendAddressPools', parameters('ExternalLoadBalancerName'), parameters('LoadBalancerBackendIPPoolNameSubnet1'))]"
                                                     }
                                                 ],
                                                 "loadBalancerInboundNatPools": [
                                                     {
-                                                        "id": "[resourceId(subscription().subscriptionId, parameters('ResourceGroupName'), 'Microsoft.Network/loadBalancers/inboundNatPools', parameters('ExternalLoadBalancerName'), parameters('ExtLBInboundNatPoolSSHBYOL'))]"
+                                                        "id": "[resourceId(subscription().subscriptionId, resourceGroup().name, 'Microsoft.Network/loadBalancers/inboundNatPools', parameters('ExternalLoadBalancerName'), parameters('ExtLBInboundNatPoolSSHBYOL'))]"
                                                     },
                                                     {
-                                                        "id": "[resourceId(subscription().subscriptionId, parameters('ResourceGroupName'), 'Microsoft.Network/loadBalancers/inboundNatPools', parameters('ExternalLoadBalancerName'), parameters('ExtLBInboundNatPoolHTTPSBYOL'))]"
+                                                        "id": "[resourceId(subscription().subscriptionId, resourceGroup().name, 'Microsoft.Network/loadBalancers/inboundNatPools', parameters('ExternalLoadBalancerName'), parameters('ExtLBInboundNatPoolHTTPSBYOL'))]"
                                                     }
                                                 ]
                                             }
@@ -388,11 +382,11 @@
                                             "name": "[concat(parameters('VmssNameBYOL'), '-ip-config','-subnet', '2')]",
                                             "properties": {
                                                 "Subnet": {
-                                                    "id": "[resourceId(subscription().subscriptionId, parameters('ResourceGroupName'), 'Microsoft.Network/virtualNetworks/subnets', parameters('VnetName'), parameters('Subnet2Name'))]"
+                                                    "id": "[resourceId(subscription().subscriptionId, resourceGroup().name, 'Microsoft.Network/virtualNetworks/subnets', parameters('VnetName'), parameters('Subnet2Name'))]"
                                                 },
                                                 "loadBalancerBackendAddressPools": [
                                                     {
-                                                        "id": "[resourceId(subscription().subscriptionId, parameters('ResourceGroupName'), 'Microsoft.Network/loadBalancers/backendAddressPools', parameters('InternalLoadBalancerName'), parameters('LoadBalancerBackendIPPoolNameSubnet2'))]"
+                                                        "id": "[resourceId(subscription().subscriptionId, resourceGroup().name, 'Microsoft.Network/loadBalancers/backendAddressPools', parameters('InternalLoadBalancerName'), parameters('LoadBalancerBackendIPPoolNameSubnet2'))]"
                                                     }
                                                 ]
                                             }
@@ -410,11 +404,11 @@
                                             "name": "[concat(parameters('VmssNameBYOL'), '-ip-config','-subnet', '3')]",
                                             "properties": {
                                                 "Subnet": {
-                                                    "id": "[resourceId(subscription().subscriptionId, parameters('ResourceGroupName'), 'Microsoft.Network/virtualNetworks/subnets', parameters('VnetName'), parameters('Subnet3Name'))]"
+                                                    "id": "[resourceId(subscription().subscriptionId, resourceGroup().name, 'Microsoft.Network/virtualNetworks/subnets', parameters('VnetName'), parameters('Subnet3Name'))]"
                                                 },
                                                 "loadBalancerBackendAddressPools": [
                                                     {
-                                                        "id": "[resourceId(subscription().subscriptionId, parameters('ResourceGroupName'), 'Microsoft.Network/loadBalancers/backendAddressPools', parameters('InternalLoadBalancerName'), parameters('LoadBalancerBackendIPPoolNameSubnet3'))]"
+                                                        "id": "[resourceId(subscription().subscriptionId, resourceGroup().name, 'Microsoft.Network/loadBalancers/backendAddressPools', parameters('InternalLoadBalancerName'), parameters('LoadBalancerBackendIPPoolNameSubnet3'))]"
                                                     }
                                                 ]
                                             }
@@ -432,11 +426,11 @@
                                             "name": "[concat(parameters('VmssNameBYOL'), '-ip-config','-subnet', '4')]",
                                             "properties": {
                                                 "Subnet": {
-                                                    "id": "[resourceId(subscription().subscriptionId, parameters('ResourceGroupName'), 'Microsoft.Network/virtualNetworks/subnets', parameters('VnetName'), parameters('Subnet4Name'))]"
+                                                    "id": "[resourceId(subscription().subscriptionId, resourceGroup().name, 'Microsoft.Network/virtualNetworks/subnets', parameters('VnetName'), parameters('Subnet4Name'))]"
                                                 },
                                                 "loadBalancerBackendAddressPools": [
                                                     {
-                                                        "id": "[resourceId(subscription().subscriptionId, parameters('ResourceGroupName'), 'Microsoft.Network/loadBalancers/backendAddressPools', parameters('InternalLoadBalancerName'), parameters('LoadBalancerBackendIPPoolNameSubnet4'))]"
+                                                        "id": "[resourceId(subscription().subscriptionId, resourceGroup().name, 'Microsoft.Network/loadBalancers/backendAddressPools', parameters('InternalLoadBalancerName'), parameters('LoadBalancerBackendIPPoolNameSubnet4'))]"
                                                     }
                                                 ]
                                             }
@@ -457,7 +451,7 @@
         },
         {
             "apiVersion": "2019-07-01",
-            "location": "[parameters('Location')]",
+            "location": "[resourceGroup().location]",
             "name": "[parameters('VmssNamePAYG')]",
             "plan": {
                 "name": "[parameters('VmImageReferenceFgtPAYG').sku]",
@@ -510,19 +504,19 @@
                                             "name": "[concat(parameters('VmssNamePAYG'), '-ip-config','-subnet', '1')]",
                                             "properties": {
                                                 "Subnet": {
-                                                    "id": "[resourceId(subscription().subscriptionId, parameters('ResourceGroupName'), 'Microsoft.Network/virtualNetworks/subnets', parameters('VnetName'), parameters('Subnet1Name'))]"
+                                                    "id": "[resourceId(subscription().subscriptionId, resourceGroup().name, 'Microsoft.Network/virtualNetworks/subnets', parameters('VnetName'), parameters('Subnet1Name'))]"
                                                 },
                                                 "loadBalancerBackendAddressPools": [
                                                     {
-                                                        "id": "[resourceId(subscription().subscriptionId, parameters('ResourceGroupName'), 'Microsoft.Network/loadBalancers/backendAddressPools', parameters('ExternalLoadBalancerName'), parameters('LoadBalancerBackendIPPoolNameSubnet1'))]"
+                                                        "id": "[resourceId(subscription().subscriptionId, resourceGroup().name, 'Microsoft.Network/loadBalancers/backendAddressPools', parameters('ExternalLoadBalancerName'), parameters('LoadBalancerBackendIPPoolNameSubnet1'))]"
                                                     }
                                                 ],
                                                 "loadBalancerInboundNatPools": [
                                                     {
-                                                        "id": "[resourceId(subscription().subscriptionId, parameters('ResourceGroupName'), 'Microsoft.Network/loadBalancers/inboundNatPools', parameters('ExternalLoadBalancerName'), parameters('ExtLBInboundNatPoolSSHPAYG'))]"
+                                                        "id": "[resourceId(subscription().subscriptionId, resourceGroup().name, 'Microsoft.Network/loadBalancers/inboundNatPools', parameters('ExternalLoadBalancerName'), parameters('ExtLBInboundNatPoolSSHPAYG'))]"
                                                     },
                                                     {
-                                                        "id": "[resourceId(subscription().subscriptionId, parameters('ResourceGroupName'), 'Microsoft.Network/loadBalancers/inboundNatPools', parameters('ExternalLoadBalancerName'), parameters('ExtLBInboundNatPoolHTTPSPAYG'))]"
+                                                        "id": "[resourceId(subscription().subscriptionId, resourceGroup().name, 'Microsoft.Network/loadBalancers/inboundNatPools', parameters('ExternalLoadBalancerName'), parameters('ExtLBInboundNatPoolHTTPSPAYG'))]"
                                                     }
                                                 ]
                                             }
@@ -540,11 +534,11 @@
                                             "name": "[concat(parameters('VmssNamePAYG'), '-ip-config','-subnet', '2')]",
                                             "properties": {
                                                 "Subnet": {
-                                                    "id": "[resourceId(subscription().subscriptionId, parameters('ResourceGroupName'), 'Microsoft.Network/virtualNetworks/subnets', parameters('VnetName'), parameters('Subnet2Name'))]"
+                                                    "id": "[resourceId(subscription().subscriptionId, resourceGroup().name, 'Microsoft.Network/virtualNetworks/subnets', parameters('VnetName'), parameters('Subnet2Name'))]"
                                                 },
                                                 "loadBalancerBackendAddressPools": [
                                                     {
-                                                        "id": "[resourceId(subscription().subscriptionId, parameters('ResourceGroupName'), 'Microsoft.Network/loadBalancers/backendAddressPools', parameters('InternalLoadBalancerName'), parameters('LoadBalancerBackendIPPoolNameSubnet2'))]"
+                                                        "id": "[resourceId(subscription().subscriptionId, resourceGroup().name, 'Microsoft.Network/loadBalancers/backendAddressPools', parameters('InternalLoadBalancerName'), parameters('LoadBalancerBackendIPPoolNameSubnet2'))]"
                                                     }
                                                 ]
                                             }
@@ -562,11 +556,11 @@
                                             "name": "[concat(parameters('VmssNamePAYG'), '-ip-config','-subnet', '3')]",
                                             "properties": {
                                                 "Subnet": {
-                                                    "id": "[resourceId(subscription().subscriptionId, parameters('ResourceGroupName'), 'Microsoft.Network/virtualNetworks/subnets', parameters('VnetName'), parameters('Subnet3Name'))]"
+                                                    "id": "[resourceId(subscription().subscriptionId, resourceGroup().name, 'Microsoft.Network/virtualNetworks/subnets', parameters('VnetName'), parameters('Subnet3Name'))]"
                                                 },
                                                 "loadBalancerBackendAddressPools": [
                                                     {
-                                                        "id": "[resourceId(subscription().subscriptionId, parameters('ResourceGroupName'), 'Microsoft.Network/loadBalancers/backendAddressPools', parameters('InternalLoadBalancerName'), parameters('LoadBalancerBackendIPPoolNameSubnet3'))]"
+                                                        "id": "[resourceId(subscription().subscriptionId, resourceGroup().name, 'Microsoft.Network/loadBalancers/backendAddressPools', parameters('InternalLoadBalancerName'), parameters('LoadBalancerBackendIPPoolNameSubnet3'))]"
                                                     }
                                                 ]
                                             }
@@ -584,11 +578,11 @@
                                             "name": "[concat(parameters('VmssNamePAYG'), '-ip-config','-subnet', '4')]",
                                             "properties": {
                                                 "Subnet": {
-                                                    "id": "[resourceId(subscription().subscriptionId, parameters('ResourceGroupName'), 'Microsoft.Network/virtualNetworks/subnets', parameters('VnetName'), parameters('Subnet4Name'))]"
+                                                    "id": "[resourceId(subscription().subscriptionId, resourceGroup().name, 'Microsoft.Network/virtualNetworks/subnets', parameters('VnetName'), parameters('Subnet4Name'))]"
                                                 },
                                                 "loadBalancerBackendAddressPools": [
                                                     {
-                                                        "id": "[resourceId(subscription().subscriptionId, parameters('ResourceGroupName'), 'Microsoft.Network/loadBalancers/backendAddressPools', parameters('InternalLoadBalancerName'), parameters('LoadBalancerBackendIPPoolNameSubnet4'))]"
+                                                        "id": "[resourceId(subscription().subscriptionId, resourceGroup().name, 'Microsoft.Network/loadBalancers/backendAddressPools', parameters('InternalLoadBalancerName'), parameters('LoadBalancerBackendIPPoolNameSubnet4'))]"
                                                     }
                                                 ]
                                             }
@@ -610,11 +604,11 @@
         {
             "apiVersion": "2014-04-01",
             "dependsOn": ["[parameters('VmssNameBYOL')]"],
-            "location": "[parameters('Location')]",
+            "location": "[resourceGroup().location]",
             "name": "[variables('autoscaleSettingsNameBYOL')]",
             "properties": {
                 "name": "[variables('autoscaleSettingsNameBYOL')]",
-                "targetResourceUri": "[concat('/subscriptions/',subscription().subscriptionId, '/resourceGroups/', parameters('ResourceGroupName'), '/providers/Microsoft.Compute/virtualMachineScaleSets/', parameters('VmssNameBYOL'))]",
+                "targetResourceUri": "[concat('/subscriptions/',subscription().subscriptionId, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachineScaleSets/', parameters('VmssNameBYOL'))]",
                 "enabled": false,
                 "profiles": [
                     {
@@ -636,11 +630,11 @@
                 "[parameters('VmssNamePAYG')]",
                 "[variables('autoscaleSettingsNameBYOL')]"
             ],
-            "location": "[parameters('Location')]",
+            "location": "[resourceGroup().location]",
             "name": "[variables('autoscaleSettingsNamePAYG')]",
             "properties": {
                 "name": "[variables('autoscaleSettingsNamePAYG')]",
-                "targetResourceUri": "[concat('/subscriptions/',subscription().subscriptionId, '/resourceGroups/',  parameters('ResourceGroupName'), '/providers/Microsoft.Compute/virtualMachineScaleSets/', parameters('VmssNamePAYG'))]",
+                "targetResourceUri": "[concat('/subscriptions/',subscription().subscriptionId, '/resourceGroups/',  resourceGroup().name, '/providers/Microsoft.Compute/virtualMachineScaleSets/', parameters('VmssNamePAYG'))]",
                 "enabled": false,
                 "profiles": [
                     {

--- a/templates/linked_template.vmss.json
+++ b/templates/linked_template.vmss.json
@@ -29,22 +29,16 @@
         "ExternalLoadBalancerName": {
             "type": "String"
         },
-        "FgtVmImageBYOL": {
-            "type": "Object"
-        },
-        "FgtVmImagePAYG": {
-            "type": "Object"
-        },
-        "FunctioinEndpointAutoscaleHandler": {
-            "type": "String"
-        },
-        "FunctioinEndpointByolLicense": {
-            "type": "String"
-        },
         "FunctionAppName": {
             "type": "String"
         },
         "FunctionAppResourceGroupName": {
+            "type": "String"
+        },
+        "FunctionNameFgtAsHandler": {
+            "type": "String"
+        },
+        "FunctionNameLicenseHandler": {
             "type": "String"
         },
         "InstanceType": {
@@ -69,41 +63,35 @@
         "LoadBalancerBackendIPPoolNameSubnet4": {
             "type": "String"
         },
+        "Location": {
+            "type": "String"
+        },
         "MaxBYOLInstanceCount": {
-            "defaultValue": 2,
-            "minValue": 0,
             "type": "Int"
         },
         "MaxPAYGInstanceCount": {
-            "defaultValue": 6,
-            "minValue": 0,
             "type": "Int"
         },
         "MinBYOLInstanceCount": {
-            "defaultValue": 2,
-            "minValue": 0,
             "type": "Int"
         },
         "MinPAYGInstanceCount": {
-            "defaultValue": 0,
-            "minValue": 0,
             "type": "Int"
         },
         "PAYGInstanceCount": {
-            "defaultValue": 0,
-            "minValue": 0,
             "type": "Int"
+        },
+        "ResourceGroupName": {
+            "type": "String"
         },
         "ResourceNamePrefix": {
             "maxLength": 10,
             "type": "String"
         },
         "ScaleInThreshold": {
-            "defaultValue": 20,
             "type": "Int"
         },
         "ScaleOutThreshold": {
-            "defaultValue": 80,
             "type": "Int"
         },
         "StorageAccountName": {
@@ -124,16 +112,19 @@
         "UniqueResourceNamePrefix": {
             "type": "String"
         },
-        "VnetName": {
-            "type": "String"
+        "VmImageReferenceFgtBYOL": {
+            "type": "Object"
         },
-        "VnetResourceGroupName": {
-            "type": "String"
+        "VmImageReferenceFgtPAYG": {
+            "type": "Object"
         },
         "VmssNameBYOL": {
             "type": "String"
         },
         "VmssNamePAYG": {
+            "type": "String"
+        },
+        "VnetName": {
             "type": "String"
         }
     },
@@ -147,7 +138,7 @@
                         "metricTrigger": {
                             "metricName": "Percentage CPU",
                             "metricNamespace": "",
-                            "metricResourceUri": "[concat('/subscriptions/',subscription().subscriptionId, '/resourceGroups/',  parameters('VnetResourceGroupName'), '/providers/Microsoft.Compute/virtualMachineScaleSets/', parameters('VmssNameBYOL'))]",
+                            "metricResourceUri": "[concat('/subscriptions/',subscription().subscriptionId, '/resourceGroups/',  parameters('ResourceGroupName'), '/providers/Microsoft.Compute/virtualMachineScaleSets/', parameters('VmssNameBYOL'))]",
                             "timeGrain": "PT1M",
                             "statistic": "Average",
                             "timeWindow": "PT5M",
@@ -166,7 +157,7 @@
                         "metricTrigger": {
                             "metricName": "Percentage CPU",
                             "metricNamespace": "",
-                            "metricResourceUri": "[concat('/subscriptions/',subscription().subscriptionId, '/resourceGroups/',  parameters('VnetResourceGroupName'), '/providers/Microsoft.Compute/virtualMachineScaleSets/', parameters('VmssNameBYOL'))]",
+                            "metricResourceUri": "[concat('/subscriptions/',subscription().subscriptionId, '/resourceGroups/',  parameters('ResourceGroupName'), '/providers/Microsoft.Compute/virtualMachineScaleSets/', parameters('VmssNameBYOL'))]",
                             "timeGrain": "PT1M",
                             "statistic": "Average",
                             "timeWindow": "PT5M",
@@ -191,7 +182,7 @@
                         "metricTrigger": {
                             "metricName": "Percentage CPU",
                             "metricNamespace": "",
-                            "metricResourceUri": "[concat('/subscriptions/',subscription().subscriptionId, '/resourceGroups/',  parameters('VnetResourceGroupName'), '/providers/Microsoft.Compute/virtualMachineScaleSets/', parameters('VmssNameBYOL'))]",
+                            "metricResourceUri": "[concat('/subscriptions/',subscription().subscriptionId, '/resourceGroups/',  parameters('ResourceGroupName'), '/providers/Microsoft.Compute/virtualMachineScaleSets/', parameters('VmssNameBYOL'))]",
                             "timeGrain": "PT1M",
                             "statistic": "Average",
                             "timeWindow": "PT5M",
@@ -210,7 +201,7 @@
                         "metricTrigger": {
                             "metricName": "Percentage CPU",
                             "metricNamespace": "",
-                            "metricResourceUri": "[concat('/subscriptions/',subscription().subscriptionId, '/resourceGroups/',  parameters('VnetResourceGroupName'), '/providers/Microsoft.Compute/virtualMachineScaleSets/', parameters('VmssNamePAYG'))]",
+                            "metricResourceUri": "[concat('/subscriptions/',subscription().subscriptionId, '/resourceGroups/',  parameters('ResourceGroupName'), '/providers/Microsoft.Compute/virtualMachineScaleSets/', parameters('VmssNamePAYG'))]",
                             "timeGrain": "PT1M",
                             "statistic": "Average",
                             "timeWindow": "PT5M",
@@ -229,7 +220,7 @@
                         "metricTrigger": {
                             "metricName": "Percentage CPU",
                             "metricNamespace": "",
-                            "metricResourceUri": "[concat('/subscriptions/',subscription().subscriptionId, '/resourceGroups/',  parameters('VnetResourceGroupName'), '/providers/Microsoft.Compute/virtualMachineScaleSets/', parameters('VmssNameBYOL'))]",
+                            "metricResourceUri": "[concat('/subscriptions/',subscription().subscriptionId, '/resourceGroups/',  parameters('ResourceGroupName'), '/providers/Microsoft.Compute/virtualMachineScaleSets/', parameters('VmssNameBYOL'))]",
                             "timeGrain": "PT1M",
                             "statistic": "Average",
                             "timeWindow": "PT5M",
@@ -248,7 +239,7 @@
                         "metricTrigger": {
                             "metricName": "Percentage CPU",
                             "metricNamespace": "",
-                            "metricResourceUri": "[concat('/subscriptions/',subscription().subscriptionId, '/resourceGroups/',  parameters('VnetResourceGroupName'), '/providers/Microsoft.Compute/virtualMachineScaleSets/', parameters('VmssNamePAYG'))]",
+                            "metricResourceUri": "[concat('/subscriptions/',subscription().subscriptionId, '/resourceGroups/',  parameters('ResourceGroupName'), '/providers/Microsoft.Compute/virtualMachineScaleSets/', parameters('VmssNamePAYG'))]",
                             "timeGrain": "PT1M",
                             "statistic": "Average",
                             "timeWindow": "PT5M",
@@ -272,7 +263,7 @@
                         "metricTrigger": {
                             "metricName": "Percentage CPU",
                             "metricNamespace": "",
-                            "metricResourceUri": "[concat('/subscriptions/',subscription().subscriptionId, '/resourceGroups/',  parameters('VnetResourceGroupName'), '/providers/Microsoft.Compute/virtualMachineScaleSets/', parameters('VmssNamePAYG'))]",
+                            "metricResourceUri": "[concat('/subscriptions/',subscription().subscriptionId, '/resourceGroups/',  parameters('ResourceGroupName'), '/providers/Microsoft.Compute/virtualMachineScaleSets/', parameters('VmssNamePAYG'))]",
                             "timeGrain": "PT1M",
                             "statistic": "Average",
                             "timeWindow": "PT5M",
@@ -291,7 +282,7 @@
                         "metricTrigger": {
                             "metricName": "Percentage CPU",
                             "metricNamespace": "",
-                            "metricResourceUri": "[concat('/subscriptions/',subscription().subscriptionId, '/resourceGroups/',  parameters('VnetResourceGroupName'), '/providers/Microsoft.Compute/virtualMachineScaleSets/', parameters('VmssNamePAYG'))]",
+                            "metricResourceUri": "[concat('/subscriptions/',subscription().subscriptionId, '/resourceGroups/',  parameters('ResourceGroupName'), '/providers/Microsoft.Compute/virtualMachineScaleSets/', parameters('VmssNamePAYG'))]",
                             "timeGrain": "PT1M",
                             "statistic": "Average",
                             "timeWindow": "PT5M",
@@ -309,18 +300,19 @@
                 ]
             }
         },
-        "cmdDeleteAutoscaleSettings": "[concat('az account set -s ', subscription().subscriptionId, ';','az monitor autoscale delete -g ', resourceGroup().name, ' -n ', variables('autoscaleSettingsNameBYOL'), ';', 'az monitor autoscale delete -g ', resourceGroup().name, ' -n ', variables('autoscaleSettingsNamePAYG'), ';')]",
-        "cmdDeleteVMSS": "[concat('az account set -s ', subscription().subscriptionId, ';','az vmss delete -g ', resourceGroup().name,' -n ', parameters('VmssNameBYOL'), ';', 'az vmss delete -g ', resourceGroup().name,' -n ', parameters('VmssNamePAYG'), ';')]"
+        "cmdDeleteAll": "[concat('az account set -s ', subscription().subscriptionId, ';', variables('cmdDeleteAutoscaleSettings'), variables('cmdDeleteVMSS'))]",
+        "cmdDeleteAutoscaleSettings": "[concat('az monitor autoscale delete', ' -g ', parameters('ResourceGroupName'), ' -n ', variables('autoscaleSettingsNameBYOL'), ';', 'az monitor autoscale delete -g ', parameters('ResourceGroupName'), ' -n ', variables('autoscaleSettingsNamePAYG'), ';')]",
+        "cmdDeleteVMSS": "[concat('az vmss delete', ' -g ', parameters('ResourceGroupName'),' -n ', parameters('VmssNameBYOL'), ';', 'az vmss delete -g ', parameters('ResourceGroupName'),' -n ', parameters('VmssNamePAYG'), ';')]"
     },
     "resources": [
         {
             "apiVersion": "2019-07-01",
-            "location": "[resourceGroup().location]",
+            "location": "[parameters('Location')]",
             "name": "[parameters('VmssNameBYOL')]",
             "plan": {
-                "name": "[parameters('FgtvmImageBYOL').sku]",
-                "publisher": "[parameters('FgtvmImageBYOL').publisher]",
-                "product": "[parameters('FgtvmImageBYOL').offer]"
+                "name": "[parameters('VmImageReferenceFgtBYOL').sku]",
+                "publisher": "[parameters('VmImageReferenceFgtBYOL').publisher]",
+                "product": "[parameters('VmImageReferenceFgtBYOL').offer]"
             },
             "properties": {
                 "overprovision": false,
@@ -340,7 +332,7 @@
                                 "createOption": "Empty"
                             }
                         ],
-                        "imageReference": "[parameters('FgtvmImageBYOL')]"
+                        "imageReference": "[parameters('VmImageReferenceFgtBYOL')]"
                     },
                     "diagnosticsProfile": {
                         "bootDiagnostics": {
@@ -351,7 +343,7 @@
                     "osProfile": {
                         "computerNamePrefix": "[parameters('VmssNameBYOL')]",
                         "adminUsername": "[parameters('adminUsername')]",
-                        "customData": "[base64(concat('{\"license-url\": \"', parameters('FunctioinEndpointByolLicense'), '?code=', listKeys(resourceId(subscription().subscriptionId, parameters('FunctionAppResourceGroupName'), 'Microsoft.Web/sites/functions', parameters('FunctionAppName'),  'byol-license'), '2019-08-01').default, '\",\"config-url\": \"', parameters('FunctioinEndpointAutoscaleHandler'), '?code=', listKeys(resourceId(subscription().subscriptionId, parameters('FunctionAppResourceGroupName'), 'Microsoft.Web/sites/functions', parameters('FunctionAppName'),  'fgt-as-handler'), '2019-08-01').default, '\"}\n'))]",
+                        "customData": "[base64(concat('{\"license-url\": \"', parameters('FunctionNameLicenseHandler'), '?code=', listKeys(resourceId(subscription().subscriptionId, parameters('FunctionAppResourceGroupName'), 'Microsoft.Web/sites/functions', parameters('FunctionAppName'),  'byol-license'), '2019-08-01').default, '\",\"config-url\": \"', parameters('FunctionNameFgtAsHandler'), '?code=', listKeys(resourceId(subscription().subscriptionId, parameters('FunctionAppResourceGroupName'), 'Microsoft.Web/sites/functions', parameters('FunctionAppName'),  'fgt-as-handler'), '2019-08-01').default, '\"}\n'))]",
                         "adminPassword": "[parameters('adminPassword')]"
                     },
                     "networkProfile": {
@@ -366,19 +358,19 @@
                                             "name": "[concat(parameters('VmssNameBYOL'), '-ip-config','-subnet', '1')]",
                                             "properties": {
                                                 "Subnet": {
-                                                    "id": "[resourceId(subscription().subscriptionId, parameters('VnetResourceGroupName'), 'Microsoft.Network/virtualNetworks/subnets', parameters('VnetName'), parameters('Subnet1Name'))]"
+                                                    "id": "[resourceId(subscription().subscriptionId, parameters('ResourceGroupName'), 'Microsoft.Network/virtualNetworks/subnets', parameters('VnetName'), parameters('Subnet1Name'))]"
                                                 },
                                                 "loadBalancerBackendAddressPools": [
                                                     {
-                                                        "id": "[resourceId(subscription().subscriptionId, parameters('VnetResourceGroupName'), 'Microsoft.Network/loadBalancers/backendAddressPools', parameters('ExternalLoadBalancerName'), parameters('LoadBalancerBackendIPPoolNameSubnet1'))]"
+                                                        "id": "[resourceId(subscription().subscriptionId, parameters('ResourceGroupName'), 'Microsoft.Network/loadBalancers/backendAddressPools', parameters('ExternalLoadBalancerName'), parameters('LoadBalancerBackendIPPoolNameSubnet1'))]"
                                                     }
                                                 ],
                                                 "loadBalancerInboundNatPools": [
                                                     {
-                                                        "id": "[resourceId(subscription().subscriptionId, parameters('VnetResourceGroupName'), 'Microsoft.Network/loadBalancers/inboundNatPools', parameters('ExternalLoadBalancerName'), parameters('ExtLBInboundNatPoolSSHBYOL'))]"
+                                                        "id": "[resourceId(subscription().subscriptionId, parameters('ResourceGroupName'), 'Microsoft.Network/loadBalancers/inboundNatPools', parameters('ExternalLoadBalancerName'), parameters('ExtLBInboundNatPoolSSHBYOL'))]"
                                                     },
                                                     {
-                                                        "id": "[resourceId(subscription().subscriptionId, parameters('VnetResourceGroupName'), 'Microsoft.Network/loadBalancers/inboundNatPools', parameters('ExternalLoadBalancerName'), parameters('ExtLBInboundNatPoolHTTPSBYOL'))]"
+                                                        "id": "[resourceId(subscription().subscriptionId, parameters('ResourceGroupName'), 'Microsoft.Network/loadBalancers/inboundNatPools', parameters('ExternalLoadBalancerName'), parameters('ExtLBInboundNatPoolHTTPSBYOL'))]"
                                                     }
                                                 ]
                                             }
@@ -396,11 +388,11 @@
                                             "name": "[concat(parameters('VmssNameBYOL'), '-ip-config','-subnet', '2')]",
                                             "properties": {
                                                 "Subnet": {
-                                                    "id": "[resourceId(subscription().subscriptionId, parameters('VnetResourceGroupName'), 'Microsoft.Network/virtualNetworks/subnets', parameters('VnetName'), parameters('Subnet2Name'))]"
+                                                    "id": "[resourceId(subscription().subscriptionId, parameters('ResourceGroupName'), 'Microsoft.Network/virtualNetworks/subnets', parameters('VnetName'), parameters('Subnet2Name'))]"
                                                 },
                                                 "loadBalancerBackendAddressPools": [
                                                     {
-                                                        "id": "[resourceId(subscription().subscriptionId, parameters('VnetResourceGroupName'), 'Microsoft.Network/loadBalancers/backendAddressPools', parameters('InternalLoadBalancerName'), parameters('LoadBalancerBackendIPPoolNameSubnet2'))]"
+                                                        "id": "[resourceId(subscription().subscriptionId, parameters('ResourceGroupName'), 'Microsoft.Network/loadBalancers/backendAddressPools', parameters('InternalLoadBalancerName'), parameters('LoadBalancerBackendIPPoolNameSubnet2'))]"
                                                     }
                                                 ]
                                             }
@@ -418,11 +410,11 @@
                                             "name": "[concat(parameters('VmssNameBYOL'), '-ip-config','-subnet', '3')]",
                                             "properties": {
                                                 "Subnet": {
-                                                    "id": "[resourceId(subscription().subscriptionId, parameters('VnetResourceGroupName'), 'Microsoft.Network/virtualNetworks/subnets', parameters('VnetName'), parameters('Subnet3Name'))]"
+                                                    "id": "[resourceId(subscription().subscriptionId, parameters('ResourceGroupName'), 'Microsoft.Network/virtualNetworks/subnets', parameters('VnetName'), parameters('Subnet3Name'))]"
                                                 },
                                                 "loadBalancerBackendAddressPools": [
                                                     {
-                                                        "id": "[resourceId(subscription().subscriptionId, parameters('VnetResourceGroupName'), 'Microsoft.Network/loadBalancers/backendAddressPools', parameters('InternalLoadBalancerName'), parameters('LoadBalancerBackendIPPoolNameSubnet3'))]"
+                                                        "id": "[resourceId(subscription().subscriptionId, parameters('ResourceGroupName'), 'Microsoft.Network/loadBalancers/backendAddressPools', parameters('InternalLoadBalancerName'), parameters('LoadBalancerBackendIPPoolNameSubnet3'))]"
                                                     }
                                                 ]
                                             }
@@ -440,11 +432,11 @@
                                             "name": "[concat(parameters('VmssNameBYOL'), '-ip-config','-subnet', '4')]",
                                             "properties": {
                                                 "Subnet": {
-                                                    "id": "[resourceId(subscription().subscriptionId, parameters('VnetResourceGroupName'), 'Microsoft.Network/virtualNetworks/subnets', parameters('VnetName'), parameters('Subnet4Name'))]"
+                                                    "id": "[resourceId(subscription().subscriptionId, parameters('ResourceGroupName'), 'Microsoft.Network/virtualNetworks/subnets', parameters('VnetName'), parameters('Subnet4Name'))]"
                                                 },
                                                 "loadBalancerBackendAddressPools": [
                                                     {
-                                                        "id": "[resourceId(subscription().subscriptionId, parameters('VnetResourceGroupName'), 'Microsoft.Network/loadBalancers/backendAddressPools', parameters('InternalLoadBalancerName'), parameters('LoadBalancerBackendIPPoolNameSubnet4'))]"
+                                                        "id": "[resourceId(subscription().subscriptionId, parameters('ResourceGroupName'), 'Microsoft.Network/loadBalancers/backendAddressPools', parameters('InternalLoadBalancerName'), parameters('LoadBalancerBackendIPPoolNameSubnet4'))]"
                                                     }
                                                 ]
                                             }
@@ -465,12 +457,12 @@
         },
         {
             "apiVersion": "2019-07-01",
-            "location": "[resourceGroup().location]",
+            "location": "[parameters('Location')]",
             "name": "[parameters('VmssNamePAYG')]",
             "plan": {
-                "name": "[parameters('FgtvmImagePAYG').sku]",
-                "publisher": "[parameters('FgtvmImagePAYG').publisher]",
-                "product": "[parameters('FgtvmImagePAYG').offer]"
+                "name": "[parameters('VmImageReferenceFgtPAYG').sku]",
+                "publisher": "[parameters('VmImageReferenceFgtPAYG').publisher]",
+                "product": "[parameters('VmImageReferenceFgtPAYG').offer]"
             },
             "properties": {
                 "overprovision": false,
@@ -490,7 +482,7 @@
                                 "createOption": "Empty"
                             }
                         ],
-                        "imageReference": "[parameters('FgtvmImagePAYG')]"
+                        "imageReference": "[parameters('VmImageReferenceFgtPAYG')]"
                     },
                     "diagnosticsProfile": {
                         "bootDiagnostics": {
@@ -502,7 +494,7 @@
                     "evictionPolicy": "delete",
                     "osProfile": {
                         "computerNamePrefix": "[parameters('VmssNamePAYG')]",
-                        "customData": "[base64(concat('{\"config-url\": \"', parameters('FunctioinEndpointAutoscaleHandler'), '?code=', listKeys(resourceId(subscription().subscriptionId, parameters('FunctionAppResourceGroupName'), 'Microsoft.Web/sites/functions', parameters('FunctionAppName'),  'fgt-as-handler'), '2019-08-01').default, '\"}\n'))]",
+                        "customData": "[base64(concat('{\"config-url\": \"', parameters('FunctionNameFgtAsHandler'), '?code=', listKeys(resourceId(subscription().subscriptionId, parameters('FunctionAppResourceGroupName'), 'Microsoft.Web/sites/functions', parameters('FunctionAppName'),  'fgt-as-handler'), '2019-08-01').default, '\"}\n'))]",
                         "adminUsername": "[parameters('adminUsername')]",
                         "adminPassword": "[parameters('adminPassword')]"
                     },
@@ -518,19 +510,19 @@
                                             "name": "[concat(parameters('VmssNamePAYG'), '-ip-config','-subnet', '1')]",
                                             "properties": {
                                                 "Subnet": {
-                                                    "id": "[resourceId(subscription().subscriptionId, parameters('VnetResourceGroupName'), 'Microsoft.Network/virtualNetworks/subnets', parameters('VnetName'), parameters('Subnet1Name'))]"
+                                                    "id": "[resourceId(subscription().subscriptionId, parameters('ResourceGroupName'), 'Microsoft.Network/virtualNetworks/subnets', parameters('VnetName'), parameters('Subnet1Name'))]"
                                                 },
                                                 "loadBalancerBackendAddressPools": [
                                                     {
-                                                        "id": "[resourceId(subscription().subscriptionId, parameters('VnetResourceGroupName'), 'Microsoft.Network/loadBalancers/backendAddressPools', parameters('ExternalLoadBalancerName'), parameters('LoadBalancerBackendIPPoolNameSubnet1'))]"
+                                                        "id": "[resourceId(subscription().subscriptionId, parameters('ResourceGroupName'), 'Microsoft.Network/loadBalancers/backendAddressPools', parameters('ExternalLoadBalancerName'), parameters('LoadBalancerBackendIPPoolNameSubnet1'))]"
                                                     }
                                                 ],
                                                 "loadBalancerInboundNatPools": [
                                                     {
-                                                        "id": "[resourceId(subscription().subscriptionId, parameters('VnetResourceGroupName'), 'Microsoft.Network/loadBalancers/inboundNatPools', parameters('ExternalLoadBalancerName'), parameters('ExtLBInboundNatPoolSSHPAYG'))]"
+                                                        "id": "[resourceId(subscription().subscriptionId, parameters('ResourceGroupName'), 'Microsoft.Network/loadBalancers/inboundNatPools', parameters('ExternalLoadBalancerName'), parameters('ExtLBInboundNatPoolSSHPAYG'))]"
                                                     },
                                                     {
-                                                        "id": "[resourceId(subscription().subscriptionId, parameters('VnetResourceGroupName'), 'Microsoft.Network/loadBalancers/inboundNatPools', parameters('ExternalLoadBalancerName'), parameters('ExtLBInboundNatPoolHTTPSPAYG'))]"
+                                                        "id": "[resourceId(subscription().subscriptionId, parameters('ResourceGroupName'), 'Microsoft.Network/loadBalancers/inboundNatPools', parameters('ExternalLoadBalancerName'), parameters('ExtLBInboundNatPoolHTTPSPAYG'))]"
                                                     }
                                                 ]
                                             }
@@ -548,11 +540,11 @@
                                             "name": "[concat(parameters('VmssNamePAYG'), '-ip-config','-subnet', '2')]",
                                             "properties": {
                                                 "Subnet": {
-                                                    "id": "[resourceId(subscription().subscriptionId, parameters('VnetResourceGroupName'), 'Microsoft.Network/virtualNetworks/subnets', parameters('VnetName'), parameters('Subnet2Name'))]"
+                                                    "id": "[resourceId(subscription().subscriptionId, parameters('ResourceGroupName'), 'Microsoft.Network/virtualNetworks/subnets', parameters('VnetName'), parameters('Subnet2Name'))]"
                                                 },
                                                 "loadBalancerBackendAddressPools": [
                                                     {
-                                                        "id": "[resourceId(subscription().subscriptionId, parameters('VnetResourceGroupName'), 'Microsoft.Network/loadBalancers/backendAddressPools', parameters('InternalLoadBalancerName'), parameters('LoadBalancerBackendIPPoolNameSubnet2'))]"
+                                                        "id": "[resourceId(subscription().subscriptionId, parameters('ResourceGroupName'), 'Microsoft.Network/loadBalancers/backendAddressPools', parameters('InternalLoadBalancerName'), parameters('LoadBalancerBackendIPPoolNameSubnet2'))]"
                                                     }
                                                 ]
                                             }
@@ -570,11 +562,11 @@
                                             "name": "[concat(parameters('VmssNamePAYG'), '-ip-config','-subnet', '3')]",
                                             "properties": {
                                                 "Subnet": {
-                                                    "id": "[resourceId(subscription().subscriptionId, parameters('VnetResourceGroupName'), 'Microsoft.Network/virtualNetworks/subnets', parameters('VnetName'), parameters('Subnet3Name'))]"
+                                                    "id": "[resourceId(subscription().subscriptionId, parameters('ResourceGroupName'), 'Microsoft.Network/virtualNetworks/subnets', parameters('VnetName'), parameters('Subnet3Name'))]"
                                                 },
                                                 "loadBalancerBackendAddressPools": [
                                                     {
-                                                        "id": "[resourceId(subscription().subscriptionId, parameters('VnetResourceGroupName'), 'Microsoft.Network/loadBalancers/backendAddressPools', parameters('InternalLoadBalancerName'), parameters('LoadBalancerBackendIPPoolNameSubnet3'))]"
+                                                        "id": "[resourceId(subscription().subscriptionId, parameters('ResourceGroupName'), 'Microsoft.Network/loadBalancers/backendAddressPools', parameters('InternalLoadBalancerName'), parameters('LoadBalancerBackendIPPoolNameSubnet3'))]"
                                                     }
                                                 ]
                                             }
@@ -592,11 +584,11 @@
                                             "name": "[concat(parameters('VmssNamePAYG'), '-ip-config','-subnet', '4')]",
                                             "properties": {
                                                 "Subnet": {
-                                                    "id": "[resourceId(subscription().subscriptionId, parameters('VnetResourceGroupName'), 'Microsoft.Network/virtualNetworks/subnets', parameters('VnetName'), parameters('Subnet4Name'))]"
+                                                    "id": "[resourceId(subscription().subscriptionId, parameters('ResourceGroupName'), 'Microsoft.Network/virtualNetworks/subnets', parameters('VnetName'), parameters('Subnet4Name'))]"
                                                 },
                                                 "loadBalancerBackendAddressPools": [
                                                     {
-                                                        "id": "[resourceId(subscription().subscriptionId, parameters('VnetResourceGroupName'), 'Microsoft.Network/loadBalancers/backendAddressPools', parameters('InternalLoadBalancerName'), parameters('LoadBalancerBackendIPPoolNameSubnet4'))]"
+                                                        "id": "[resourceId(subscription().subscriptionId, parameters('ResourceGroupName'), 'Microsoft.Network/loadBalancers/backendAddressPools', parameters('InternalLoadBalancerName'), parameters('LoadBalancerBackendIPPoolNameSubnet4'))]"
                                                     }
                                                 ]
                                             }
@@ -618,11 +610,11 @@
         {
             "apiVersion": "2014-04-01",
             "dependsOn": ["[parameters('VmssNameBYOL')]"],
-            "location": "[resourceGroup().location]",
+            "location": "[parameters('Location')]",
             "name": "[variables('autoscaleSettingsNameBYOL')]",
             "properties": {
                 "name": "[variables('autoscaleSettingsNameBYOL')]",
-                "targetResourceUri": "[concat('/subscriptions/',subscription().subscriptionId, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachineScaleSets/', parameters('VmssNameBYOL'))]",
+                "targetResourceUri": "[concat('/subscriptions/',subscription().subscriptionId, '/resourceGroups/', parameters('ResourceGroupName'), '/providers/Microsoft.Compute/virtualMachineScaleSets/', parameters('VmssNameBYOL'))]",
                 "enabled": false,
                 "profiles": [
                     {
@@ -644,11 +636,11 @@
                 "[parameters('VmssNamePAYG')]",
                 "[variables('autoscaleSettingsNameBYOL')]"
             ],
-            "location": "[resourceGroup().location]",
+            "location": "[parameters('Location')]",
             "name": "[variables('autoscaleSettingsNamePAYG')]",
             "properties": {
                 "name": "[variables('autoscaleSettingsNamePAYG')]",
-                "targetResourceUri": "[concat('/subscriptions/',subscription().subscriptionId, '/resourceGroups/',  resourceGroup().name, '/providers/Microsoft.Compute/virtualMachineScaleSets/', parameters('VmssNamePAYG'))]",
+                "targetResourceUri": "[concat('/subscriptions/',subscription().subscriptionId, '/resourceGroups/',  parameters('ResourceGroupName'), '/providers/Microsoft.Compute/virtualMachineScaleSets/', parameters('VmssNamePAYG'))]",
                 "enabled": false,
                 "profiles": [
                     {
@@ -686,13 +678,9 @@
             "type": "String",
             "value": "[parameters('VmssNameBYOL')]"
         },
-        "cmdDeleteAutoscaleSettings": {
+        "cmdDeleteAll": {
             "type": "String",
-            "value": "[variables('cmdDeleteAutoscaleSettings')]"
-        },
-        "cmdDeleteVMSS": {
-            "type": "String",
-            "value": "[variables('cmdDeleteVMSS')]"
+            "value": "[variables('cmdDeleteAll')]"
         },
         "paygAutoscaleSettingsName": {
             "type": "String",
@@ -713,10 +701,6 @@
         "paygScaleSetName": {
             "type": "String",
             "value": "[parameters('VmssNamePAYG')]"
-        },
-        "vNetResourceGroupName": {
-            "type": "String",
-            "value": "[parameters('VnetResourceGroupName')]"
         }
     }
 }

--- a/templates/linked_template.vmss.json
+++ b/templates/linked_template.vmss.json
@@ -1,0 +1,722 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "3.3.0.0",
+    "parameters": {
+        "AdminPassword": {
+            "type": "SecureString"
+        },
+        "AdminUsername": {
+            "defaultValue": "azureadmin",
+            "type": "String"
+        },
+        "BYOLInstanceCount": {
+            "defaultValue": 2,
+            "minValue": 0,
+            "type": "Int"
+        },
+        "ExtLBInboundNatPoolHTTPSBYOL": {
+            "type": "String"
+        },
+        "ExtLBInboundNatPoolHTTPSPAYG": {
+            "type": "String"
+        },
+        "ExtLBInboundNatPoolSSHBYOL": {
+            "type": "String"
+        },
+        "ExtLBInboundNatPoolSSHPAYG": {
+            "type": "String"
+        },
+        "ExternalLoadBalancerName": {
+            "type": "String"
+        },
+        "FgtVmImageBYOL": {
+            "type": "Object"
+        },
+        "FgtVmImagePAYG": {
+            "type": "Object"
+        },
+        "FunctioinEndpointAutoscaleHandler": {
+            "type": "String"
+        },
+        "FunctioinEndpointByolLicense": {
+            "type": "String"
+        },
+        "FunctionAppName": {
+            "type": "String"
+        },
+        "FunctionAppResourceGroupName": {
+            "type": "String"
+        },
+        "InstanceType": {
+            "type": "String"
+        },
+        "InternalLoadBalancerName": {
+            "type": "String"
+        },
+        "LicensingModel": {
+            "allowedValues": ["byolonly", "hybrid", "paygonly"],
+            "type": "String"
+        },
+        "LoadBalancerBackendIPPoolNameSubnet1": {
+            "type": "String"
+        },
+        "LoadBalancerBackendIPPoolNameSubnet2": {
+            "type": "String"
+        },
+        "LoadBalancerBackendIPPoolNameSubnet3": {
+            "type": "String"
+        },
+        "LoadBalancerBackendIPPoolNameSubnet4": {
+            "type": "String"
+        },
+        "MaxBYOLInstanceCount": {
+            "defaultValue": 2,
+            "minValue": 0,
+            "type": "Int"
+        },
+        "MaxPAYGInstanceCount": {
+            "defaultValue": 6,
+            "minValue": 0,
+            "type": "Int"
+        },
+        "MinBYOLInstanceCount": {
+            "defaultValue": 2,
+            "minValue": 0,
+            "type": "Int"
+        },
+        "MinPAYGInstanceCount": {
+            "defaultValue": 0,
+            "minValue": 0,
+            "type": "Int"
+        },
+        "PAYGInstanceCount": {
+            "defaultValue": 0,
+            "minValue": 0,
+            "type": "Int"
+        },
+        "ResourceNamePrefix": {
+            "maxLength": 10,
+            "type": "String"
+        },
+        "ScaleInThreshold": {
+            "defaultValue": 20,
+            "type": "Int"
+        },
+        "ScaleOutThreshold": {
+            "defaultValue": 80,
+            "type": "Int"
+        },
+        "StorageAccountName": {
+            "type": "String"
+        },
+        "Subnet1Name": {
+            "type": "String"
+        },
+        "Subnet2Name": {
+            "type": "String"
+        },
+        "Subnet3Name": {
+            "type": "String"
+        },
+        "Subnet4Name": {
+            "type": "String"
+        },
+        "UniqueResourceNamePrefix": {
+            "type": "String"
+        },
+        "VnetName": {
+            "type": "String"
+        },
+        "VnetResourceGroupName": {
+            "type": "String"
+        },
+        "VmssNameBYOL": {
+            "type": "String"
+        },
+        "VmssNamePAYG": {
+            "type": "String"
+        }
+    },
+    "variables": {
+        "autoscaleSettingsNameBYOL": "[concat(parameters('ResourceNamePrefix'), '-autoscalesettings-byol')]",
+        "autoscaleSettingsNamePAYG": "[concat(parameters('ResourceNamePrefix'), '-autoscalesettings-payg')]",
+        "autoscaleSettingsPresets": {
+            "byolonly": {
+                "byol": [
+                    {
+                        "metricTrigger": {
+                            "metricName": "Percentage CPU",
+                            "metricNamespace": "",
+                            "metricResourceUri": "[concat('/subscriptions/',subscription().subscriptionId, '/resourceGroups/',  parameters('VnetResourceGroupName'), '/providers/Microsoft.Compute/virtualMachineScaleSets/', parameters('VmssNameBYOL'))]",
+                            "timeGrain": "PT1M",
+                            "statistic": "Average",
+                            "timeWindow": "PT5M",
+                            "timeAggregation": "Average",
+                            "operator": "GreaterThan",
+                            "threshold": "[parameters('ScaleOutThreshold')]"
+                        },
+                        "scaleAction": {
+                            "direction": "Increase",
+                            "type": "ChangeCount",
+                            "value": "1",
+                            "cooldown": "PT1M"
+                        }
+                    },
+                    {
+                        "metricTrigger": {
+                            "metricName": "Percentage CPU",
+                            "metricNamespace": "",
+                            "metricResourceUri": "[concat('/subscriptions/',subscription().subscriptionId, '/resourceGroups/',  parameters('VnetResourceGroupName'), '/providers/Microsoft.Compute/virtualMachineScaleSets/', parameters('VmssNameBYOL'))]",
+                            "timeGrain": "PT1M",
+                            "statistic": "Average",
+                            "timeWindow": "PT5M",
+                            "timeAggregation": "Average",
+                            "operator": "LessThan",
+                            "threshold": "[parameters('ScaleInThreshold')]"
+                        },
+                        "scaleAction": {
+                            "direction": "Decrease",
+                            "type": "ChangeCount",
+                            "value": "1",
+                            "cooldown": "PT1M"
+                        }
+                    }
+                ],
+                "payg": []
+            },
+            "hybrid": {
+                "byol": [],
+                "payg": [
+                    {
+                        "metricTrigger": {
+                            "metricName": "Percentage CPU",
+                            "metricNamespace": "",
+                            "metricResourceUri": "[concat('/subscriptions/',subscription().subscriptionId, '/resourceGroups/',  parameters('VnetResourceGroupName'), '/providers/Microsoft.Compute/virtualMachineScaleSets/', parameters('VmssNameBYOL'))]",
+                            "timeGrain": "PT1M",
+                            "statistic": "Average",
+                            "timeWindow": "PT5M",
+                            "timeAggregation": "Average",
+                            "operator": "GreaterThan",
+                            "threshold": "[parameters('ScaleOutThreshold')]"
+                        },
+                        "scaleAction": {
+                            "direction": "Increase",
+                            "type": "ChangeCount",
+                            "value": "1",
+                            "cooldown": "PT1M"
+                        }
+                    },
+                    {
+                        "metricTrigger": {
+                            "metricName": "Percentage CPU",
+                            "metricNamespace": "",
+                            "metricResourceUri": "[concat('/subscriptions/',subscription().subscriptionId, '/resourceGroups/',  parameters('VnetResourceGroupName'), '/providers/Microsoft.Compute/virtualMachineScaleSets/', parameters('VmssNamePAYG'))]",
+                            "timeGrain": "PT1M",
+                            "statistic": "Average",
+                            "timeWindow": "PT5M",
+                            "timeAggregation": "Average",
+                            "operator": "GreaterThan",
+                            "threshold": "[parameters('ScaleOutThreshold')]"
+                        },
+                        "scaleAction": {
+                            "direction": "Increase",
+                            "type": "ChangeCount",
+                            "value": "1",
+                            "cooldown": "PT1M"
+                        }
+                    },
+                    {
+                        "metricTrigger": {
+                            "metricName": "Percentage CPU",
+                            "metricNamespace": "",
+                            "metricResourceUri": "[concat('/subscriptions/',subscription().subscriptionId, '/resourceGroups/',  parameters('VnetResourceGroupName'), '/providers/Microsoft.Compute/virtualMachineScaleSets/', parameters('VmssNameBYOL'))]",
+                            "timeGrain": "PT1M",
+                            "statistic": "Average",
+                            "timeWindow": "PT5M",
+                            "timeAggregation": "Average",
+                            "operator": "LessThan",
+                            "threshold": "[parameters('ScaleInThreshold')]"
+                        },
+                        "scaleAction": {
+                            "direction": "Decrease",
+                            "type": "ChangeCount",
+                            "value": "1",
+                            "cooldown": "PT1M"
+                        }
+                    },
+                    {
+                        "metricTrigger": {
+                            "metricName": "Percentage CPU",
+                            "metricNamespace": "",
+                            "metricResourceUri": "[concat('/subscriptions/',subscription().subscriptionId, '/resourceGroups/',  parameters('VnetResourceGroupName'), '/providers/Microsoft.Compute/virtualMachineScaleSets/', parameters('VmssNamePAYG'))]",
+                            "timeGrain": "PT1M",
+                            "statistic": "Average",
+                            "timeWindow": "PT5M",
+                            "timeAggregation": "Average",
+                            "operator": "LessThan",
+                            "threshold": "[parameters('ScaleInThreshold')]"
+                        },
+                        "scaleAction": {
+                            "direction": "Decrease",
+                            "type": "ChangeCount",
+                            "value": "1",
+                            "cooldown": "PT1M"
+                        }
+                    }
+                ]
+            },
+            "paygonly": {
+                "byol": [],
+                "payg": [
+                    {
+                        "metricTrigger": {
+                            "metricName": "Percentage CPU",
+                            "metricNamespace": "",
+                            "metricResourceUri": "[concat('/subscriptions/',subscription().subscriptionId, '/resourceGroups/',  parameters('VnetResourceGroupName'), '/providers/Microsoft.Compute/virtualMachineScaleSets/', parameters('VmssNamePAYG'))]",
+                            "timeGrain": "PT1M",
+                            "statistic": "Average",
+                            "timeWindow": "PT5M",
+                            "timeAggregation": "Average",
+                            "operator": "GreaterThan",
+                            "threshold": "[parameters('ScaleOutThreshold')]"
+                        },
+                        "scaleAction": {
+                            "direction": "Increase",
+                            "type": "ChangeCount",
+                            "value": "1",
+                            "cooldown": "PT1M"
+                        }
+                    },
+                    {
+                        "metricTrigger": {
+                            "metricName": "Percentage CPU",
+                            "metricNamespace": "",
+                            "metricResourceUri": "[concat('/subscriptions/',subscription().subscriptionId, '/resourceGroups/',  parameters('VnetResourceGroupName'), '/providers/Microsoft.Compute/virtualMachineScaleSets/', parameters('VmssNamePAYG'))]",
+                            "timeGrain": "PT1M",
+                            "statistic": "Average",
+                            "timeWindow": "PT5M",
+                            "timeAggregation": "Average",
+                            "operator": "LessThan",
+                            "threshold": "[parameters('ScaleInThreshold')]"
+                        },
+                        "scaleAction": {
+                            "direction": "Decrease",
+                            "type": "ChangeCount",
+                            "value": "1",
+                            "cooldown": "PT1M"
+                        }
+                    }
+                ]
+            }
+        },
+        "cmdDeleteAutoscaleSettings": "[concat('az account set -s ', subscription().subscriptionId, ';','az monitor autoscale delete -g ', resourceGroup().name, ' -n ', variables('autoscaleSettingsNameBYOL'), ';', 'az monitor autoscale delete -g ', resourceGroup().name, ' -n ', variables('autoscaleSettingsNamePAYG'), ';')]",
+        "cmdDeleteVMSS": "[concat('az account set -s ', subscription().subscriptionId, ';','az vmss delete -g ', resourceGroup().name,' -n ', parameters('VmssNameBYOL'), ';', 'az vmss delete -g ', resourceGroup().name,' -n ', parameters('VmssNamePAYG'), ';')]"
+    },
+    "resources": [
+        {
+            "apiVersion": "2019-07-01",
+            "location": "[resourceGroup().location]",
+            "name": "[parameters('VmssNameBYOL')]",
+            "plan": {
+                "name": "[parameters('FgtvmImageBYOL').sku]",
+                "publisher": "[parameters('FgtvmImageBYOL').publisher]",
+                "product": "[parameters('FgtvmImageBYOL').offer]"
+            },
+            "properties": {
+                "overprovision": false,
+                "upgradePolicy": {
+                    "mode": "Manual"
+                },
+                "virtualMachineProfile": {
+                    "storageProfile": {
+                        "osDisk": {
+                            "createOption": "FromImage",
+                            "caching": "ReadWrite"
+                        },
+                        "dataDisks": [
+                            {
+                                "diskSizeGB": 30,
+                                "lun": 1,
+                                "createOption": "Empty"
+                            }
+                        ],
+                        "imageReference": "[parameters('FgtvmImageBYOL')]"
+                    },
+                    "diagnosticsProfile": {
+                        "bootDiagnostics": {
+                            "enabled": true,
+                            "storageUri": "[concat('https://', parameters('StorageAccountName'), '.blob.core.windows.net')]"
+                        }
+                    },
+                    "osProfile": {
+                        "computerNamePrefix": "[parameters('VmssNameBYOL')]",
+                        "adminUsername": "[parameters('adminUsername')]",
+                        "customData": "[base64(concat('{\"license-url\": \"', parameters('FunctioinEndpointByolLicense'), '?code=', listKeys(resourceId(subscription().subscriptionId, parameters('FunctionAppResourceGroupName'), 'Microsoft.Web/sites/functions', parameters('FunctionAppName'),  'byol-license'), '2019-08-01').default, '\",\"config-url\": \"', parameters('FunctioinEndpointAutoscaleHandler'), '?code=', listKeys(resourceId(subscription().subscriptionId, parameters('FunctionAppResourceGroupName'), 'Microsoft.Web/sites/functions', parameters('FunctionAppName'),  'fgt-as-handler'), '2019-08-01').default, '\"}\n'))]",
+                        "adminPassword": "[parameters('adminPassword')]"
+                    },
+                    "networkProfile": {
+                        "networkInterfaceConfigurations": [
+                            {
+                                "name": "[concat(parameters('VmssNameBYOL'),'-nic-config', '-subnet', '1')]",
+                                "properties": {
+                                    "primary": true,
+                                    "enableIPForwarding": true,
+                                    "ipConfigurations": [
+                                        {
+                                            "name": "[concat(parameters('VmssNameBYOL'), '-ip-config','-subnet', '1')]",
+                                            "properties": {
+                                                "Subnet": {
+                                                    "id": "[resourceId(subscription().subscriptionId, parameters('VnetResourceGroupName'), 'Microsoft.Network/virtualNetworks/subnets', parameters('VnetName'), parameters('Subnet1Name'))]"
+                                                },
+                                                "loadBalancerBackendAddressPools": [
+                                                    {
+                                                        "id": "[resourceId(subscription().subscriptionId, parameters('VnetResourceGroupName'), 'Microsoft.Network/loadBalancers/backendAddressPools', parameters('ExternalLoadBalancerName'), parameters('LoadBalancerBackendIPPoolNameSubnet1'))]"
+                                                    }
+                                                ],
+                                                "loadBalancerInboundNatPools": [
+                                                    {
+                                                        "id": "[resourceId(subscription().subscriptionId, parameters('VnetResourceGroupName'), 'Microsoft.Network/loadBalancers/inboundNatPools', parameters('ExternalLoadBalancerName'), parameters('ExtLBInboundNatPoolSSHBYOL'))]"
+                                                    },
+                                                    {
+                                                        "id": "[resourceId(subscription().subscriptionId, parameters('VnetResourceGroupName'), 'Microsoft.Network/loadBalancers/inboundNatPools', parameters('ExternalLoadBalancerName'), parameters('ExtLBInboundNatPoolHTTPSBYOL'))]"
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "name": "[concat(parameters('VmssNameBYOL'),'-nic-config', '-subnet', '2')]",
+                                "properties": {
+                                    "primary": false,
+                                    "enableIPForwarding": true,
+                                    "ipConfigurations": [
+                                        {
+                                            "name": "[concat(parameters('VmssNameBYOL'), '-ip-config','-subnet', '2')]",
+                                            "properties": {
+                                                "Subnet": {
+                                                    "id": "[resourceId(subscription().subscriptionId, parameters('VnetResourceGroupName'), 'Microsoft.Network/virtualNetworks/subnets', parameters('VnetName'), parameters('Subnet2Name'))]"
+                                                },
+                                                "loadBalancerBackendAddressPools": [
+                                                    {
+                                                        "id": "[resourceId(subscription().subscriptionId, parameters('VnetResourceGroupName'), 'Microsoft.Network/loadBalancers/backendAddressPools', parameters('InternalLoadBalancerName'), parameters('LoadBalancerBackendIPPoolNameSubnet2'))]"
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "name": "[concat(parameters('VmssNameBYOL'),'-nic-config', '-subnet', '3')]",
+                                "properties": {
+                                    "primary": false,
+                                    "enableIPForwarding": true,
+                                    "ipConfigurations": [
+                                        {
+                                            "name": "[concat(parameters('VmssNameBYOL'), '-ip-config','-subnet', '3')]",
+                                            "properties": {
+                                                "Subnet": {
+                                                    "id": "[resourceId(subscription().subscriptionId, parameters('VnetResourceGroupName'), 'Microsoft.Network/virtualNetworks/subnets', parameters('VnetName'), parameters('Subnet3Name'))]"
+                                                },
+                                                "loadBalancerBackendAddressPools": [
+                                                    {
+                                                        "id": "[resourceId(subscription().subscriptionId, parameters('VnetResourceGroupName'), 'Microsoft.Network/loadBalancers/backendAddressPools', parameters('InternalLoadBalancerName'), parameters('LoadBalancerBackendIPPoolNameSubnet3'))]"
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "name": "[concat(parameters('VmssNameBYOL'),'-nic-config', '-subnet', '4')]",
+                                "properties": {
+                                    "primary": false,
+                                    "enableIPForwarding": true,
+                                    "ipConfigurations": [
+                                        {
+                                            "name": "[concat(parameters('VmssNameBYOL'), '-ip-config','-subnet', '4')]",
+                                            "properties": {
+                                                "Subnet": {
+                                                    "id": "[resourceId(subscription().subscriptionId, parameters('VnetResourceGroupName'), 'Microsoft.Network/virtualNetworks/subnets', parameters('VnetName'), parameters('Subnet4Name'))]"
+                                                },
+                                                "loadBalancerBackendAddressPools": [
+                                                    {
+                                                        "id": "[resourceId(subscription().subscriptionId, parameters('VnetResourceGroupName'), 'Microsoft.Network/loadBalancers/backendAddressPools', parameters('InternalLoadBalancerName'), parameters('LoadBalancerBackendIPPoolNameSubnet4'))]"
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            },
+            "sku": {
+                "name": "[parameters('InstanceType')]",
+                "tier": "Standard",
+                "capacity": 0
+            },
+            "type": "Microsoft.Compute/virtualMachineScaleSets"
+        },
+        {
+            "apiVersion": "2019-07-01",
+            "location": "[resourceGroup().location]",
+            "name": "[parameters('VmssNamePAYG')]",
+            "plan": {
+                "name": "[parameters('FgtvmImagePAYG').sku]",
+                "publisher": "[parameters('FgtvmImagePAYG').publisher]",
+                "product": "[parameters('FgtvmImagePAYG').offer]"
+            },
+            "properties": {
+                "overprovision": false,
+                "upgradePolicy": {
+                    "mode": "Manual"
+                },
+                "virtualMachineProfile": {
+                    "storageProfile": {
+                        "osDisk": {
+                            "createOption": "FromImage",
+                            "caching": "ReadWrite"
+                        },
+                        "dataDisks": [
+                            {
+                                "diskSizeGB": 30,
+                                "lun": 1,
+                                "createOption": "Empty"
+                            }
+                        ],
+                        "imageReference": "[parameters('FgtvmImagePAYG')]"
+                    },
+                    "diagnosticsProfile": {
+                        "bootDiagnostics": {
+                            "enabled": true,
+                            "storageUri": "[concat('https://', parameters('StorageAccountName'), '.blob.core.windows.net')]"
+                        }
+                    },
+                    "priority": "Low",
+                    "evictionPolicy": "delete",
+                    "osProfile": {
+                        "computerNamePrefix": "[parameters('VmssNamePAYG')]",
+                        "customData": "[base64(concat('{\"config-url\": \"', parameters('FunctioinEndpointAutoscaleHandler'), '?code=', listKeys(resourceId(subscription().subscriptionId, parameters('FunctionAppResourceGroupName'), 'Microsoft.Web/sites/functions', parameters('FunctionAppName'),  'fgt-as-handler'), '2019-08-01').default, '\"}\n'))]",
+                        "adminUsername": "[parameters('adminUsername')]",
+                        "adminPassword": "[parameters('adminPassword')]"
+                    },
+                    "networkProfile": {
+                        "networkInterfaceConfigurations": [
+                            {
+                                "name": "[concat(parameters('VmssNamePAYG'),'-nic-config', '-subnet', '1')]",
+                                "properties": {
+                                    "primary": true,
+                                    "enableIPForwarding": true,
+                                    "ipConfigurations": [
+                                        {
+                                            "name": "[concat(parameters('VmssNamePAYG'), '-ip-config','-subnet', '1')]",
+                                            "properties": {
+                                                "Subnet": {
+                                                    "id": "[resourceId(subscription().subscriptionId, parameters('VnetResourceGroupName'), 'Microsoft.Network/virtualNetworks/subnets', parameters('VnetName'), parameters('Subnet1Name'))]"
+                                                },
+                                                "loadBalancerBackendAddressPools": [
+                                                    {
+                                                        "id": "[resourceId(subscription().subscriptionId, parameters('VnetResourceGroupName'), 'Microsoft.Network/loadBalancers/backendAddressPools', parameters('ExternalLoadBalancerName'), parameters('LoadBalancerBackendIPPoolNameSubnet1'))]"
+                                                    }
+                                                ],
+                                                "loadBalancerInboundNatPools": [
+                                                    {
+                                                        "id": "[resourceId(subscription().subscriptionId, parameters('VnetResourceGroupName'), 'Microsoft.Network/loadBalancers/inboundNatPools', parameters('ExternalLoadBalancerName'), parameters('ExtLBInboundNatPoolSSHPAYG'))]"
+                                                    },
+                                                    {
+                                                        "id": "[resourceId(subscription().subscriptionId, parameters('VnetResourceGroupName'), 'Microsoft.Network/loadBalancers/inboundNatPools', parameters('ExternalLoadBalancerName'), parameters('ExtLBInboundNatPoolHTTPSPAYG'))]"
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "name": "[concat(parameters('VmssNamePAYG'),'-nic-config', '-subnet', '2')]",
+                                "properties": {
+                                    "primary": false,
+                                    "enableIPForwarding": true,
+                                    "ipConfigurations": [
+                                        {
+                                            "name": "[concat(parameters('VmssNamePAYG'), '-ip-config','-subnet', '2')]",
+                                            "properties": {
+                                                "Subnet": {
+                                                    "id": "[resourceId(subscription().subscriptionId, parameters('VnetResourceGroupName'), 'Microsoft.Network/virtualNetworks/subnets', parameters('VnetName'), parameters('Subnet2Name'))]"
+                                                },
+                                                "loadBalancerBackendAddressPools": [
+                                                    {
+                                                        "id": "[resourceId(subscription().subscriptionId, parameters('VnetResourceGroupName'), 'Microsoft.Network/loadBalancers/backendAddressPools', parameters('InternalLoadBalancerName'), parameters('LoadBalancerBackendIPPoolNameSubnet2'))]"
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "name": "[concat(parameters('VmssNamePAYG'),'-nic-config', '-subnet', '3')]",
+                                "properties": {
+                                    "primary": false,
+                                    "enableIPForwarding": true,
+                                    "ipConfigurations": [
+                                        {
+                                            "name": "[concat(parameters('VmssNamePAYG'), '-ip-config','-subnet', '3')]",
+                                            "properties": {
+                                                "Subnet": {
+                                                    "id": "[resourceId(subscription().subscriptionId, parameters('VnetResourceGroupName'), 'Microsoft.Network/virtualNetworks/subnets', parameters('VnetName'), parameters('Subnet3Name'))]"
+                                                },
+                                                "loadBalancerBackendAddressPools": [
+                                                    {
+                                                        "id": "[resourceId(subscription().subscriptionId, parameters('VnetResourceGroupName'), 'Microsoft.Network/loadBalancers/backendAddressPools', parameters('InternalLoadBalancerName'), parameters('LoadBalancerBackendIPPoolNameSubnet3'))]"
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "name": "[concat(parameters('VmssNamePAYG'),'-nic-config', '-subnet', '4')]",
+                                "properties": {
+                                    "primary": false,
+                                    "enableIPForwarding": true,
+                                    "ipConfigurations": [
+                                        {
+                                            "name": "[concat(parameters('VmssNamePAYG'), '-ip-config','-subnet', '4')]",
+                                            "properties": {
+                                                "Subnet": {
+                                                    "id": "[resourceId(subscription().subscriptionId, parameters('VnetResourceGroupName'), 'Microsoft.Network/virtualNetworks/subnets', parameters('VnetName'), parameters('Subnet4Name'))]"
+                                                },
+                                                "loadBalancerBackendAddressPools": [
+                                                    {
+                                                        "id": "[resourceId(subscription().subscriptionId, parameters('VnetResourceGroupName'), 'Microsoft.Network/loadBalancers/backendAddressPools', parameters('InternalLoadBalancerName'), parameters('LoadBalancerBackendIPPoolNameSubnet4'))]"
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            },
+            "sku": {
+                "name": "[parameters('InstanceType')]",
+                "tier": "Standard",
+                "capacity": 0
+            },
+            "type": "Microsoft.Compute/virtualMachineScaleSets"
+        },
+        {
+            "apiVersion": "2014-04-01",
+            "dependsOn": ["[parameters('VmssNameBYOL')]"],
+            "location": "[resourceGroup().location]",
+            "name": "[variables('autoscaleSettingsNameBYOL')]",
+            "properties": {
+                "name": "[variables('autoscaleSettingsNameBYOL')]",
+                "targetResourceUri": "[concat('/subscriptions/',subscription().subscriptionId, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.Compute/virtualMachineScaleSets/', parameters('VmssNameBYOL'))]",
+                "enabled": false,
+                "profiles": [
+                    {
+                        "name": "[concat(parameters('UniqueResourceNamePrefix'),'-deployed-profile')]",
+                        "capacity": {
+                            "minimum": "[parameters('MinBYOLInstanceCount')]",
+                            "maximum": "[parameters('MaxBYOLInstanceCount')]",
+                            "default": "[parameters('BYOLInstanceCount')]"
+                        },
+                        "rules": "[variables('autoscaleSettingsPresets')[parameters('LicensingModel')].byol]"
+                    }
+                ]
+            },
+            "type": "Microsoft.Insights/autoscaleSettings"
+        },
+        {
+            "apiVersion": "2014-04-01",
+            "dependsOn": [
+                "[parameters('VmssNamePAYG')]",
+                "[variables('autoscaleSettingsNameBYOL')]"
+            ],
+            "location": "[resourceGroup().location]",
+            "name": "[variables('autoscaleSettingsNamePAYG')]",
+            "properties": {
+                "name": "[variables('autoscaleSettingsNamePAYG')]",
+                "targetResourceUri": "[concat('/subscriptions/',subscription().subscriptionId, '/resourceGroups/',  resourceGroup().name, '/providers/Microsoft.Compute/virtualMachineScaleSets/', parameters('VmssNamePAYG'))]",
+                "enabled": false,
+                "profiles": [
+                    {
+                        "name": "[concat(parameters('UniqueResourceNamePrefix'),'-deployed-profile')]",
+                        "capacity": {
+                            "minimum": "[parameters('MinPAYGInstanceCount')]",
+                            "maximum": "[parameters('MaxPAYGInstanceCount')]",
+                            "default": "[parameters('PAYGInstanceCount')]"
+                        },
+                        "rules": "[variables('autoscaleSettingsPresets')[parameters('LicensingModel')].payg]"
+                    }
+                ]
+            },
+            "type": "Microsoft.Insights/autoscaleSettings"
+        }
+    ],
+    "outputs": {
+        "byolAutoscaleSettingsName": {
+            "type": "String",
+            "value": "[variables('autoscaleSettingsNameBYOL')]"
+        },
+        "byolScaleSetDefaultSize": {
+            "type": "Int",
+            "value": "[parameters('BYOLInstanceCount')]"
+        },
+        "byolScaleSetMaxSize": {
+            "type": "Int",
+            "value": "[parameters('MaxBYOLInstanceCount')]"
+        },
+        "byolScaleSetMinSize": {
+            "type": "Int",
+            "value": "[parameters('MinBYOLInstanceCount')]"
+        },
+        "byolScaleSetName": {
+            "type": "String",
+            "value": "[parameters('VmssNameBYOL')]"
+        },
+        "cmdDeleteAutoscaleSettings": {
+            "type": "String",
+            "value": "[variables('cmdDeleteAutoscaleSettings')]"
+        },
+        "cmdDeleteVMSS": {
+            "type": "String",
+            "value": "[variables('cmdDeleteVMSS')]"
+        },
+        "paygAutoscaleSettingsName": {
+            "type": "String",
+            "value": "[variables('autoscaleSettingsNamePAYG')]"
+        },
+        "paygScaleSetDefaultSize": {
+            "type": "Int",
+            "value": "[parameters('PAYGInstanceCount')]"
+        },
+        "paygScaleSetMaxSize": {
+            "type": "Int",
+            "value": "[parameters('MaxPAYGInstanceCount')]"
+        },
+        "paygScaleSetMinSize": {
+            "type": "Int",
+            "value": "[parameters('MinPAYGInstanceCount')]"
+        },
+        "paygScaleSetName": {
+            "type": "String",
+            "value": "[parameters('VmssNamePAYG')]"
+        },
+        "vNetResourceGroupName": {
+            "type": "String",
+            "value": "[parameters('VnetResourceGroupName')]"
+        }
+    }
+}


### PR DESCRIPTION
Restructure the Azure templates by moving some resources to separates link templates.

The goal of these changes is to fully secure the function keys in the template deployments so none will be visible in either input or output.

Resolve issue #10 