### PR TITLE
fix error in deploying without faz

### DIFF
--- a/scripts/sync-version.ts
+++ b/scripts/sync-version.ts
@@ -72,6 +72,11 @@ files
                     templateJSON.parameters[
                         key
                     ].defaultValue = `https://github.com/fortinet/fortigate-autoscale-azure/releases/download/${verStr}/fortigate-autoscale-azure-funcapp.zip`;
+                    console.log(
+                        `Function app zip file url: ${chalk.green(
+                            templateJSON.parameters[key].defaultValue
+                        )}.`
+                    );
                 }
             });
         }

--- a/templates/deploy_fortigate_autoscale.hybrid_licensing.json
+++ b/templates/deploy_fortigate_autoscale.hybrid_licensing.json
@@ -54,6 +54,14 @@
                 "description": "Size of the FortiAnalyzer VM."
             }
         },
+        "FortiAnalyzerIntegrationOptions": {
+            "defaultValue": "yes",
+            "allowedValues": ["yes", "no"],
+            "type": "String",
+            "metadata": {
+                "description": "Choose 'yes' to incorporate FortiAnalyzer into Fortinet FortiGate Auto Scaling to use extended features that include storing logs into FortiAnalyzer."
+            }
+        },
         "FortiAnalyzerVersion": {
             "defaultValue": "6.4.5",
             "allowedValues": ["6.4.5", "6.2.5"],
@@ -355,7 +363,7 @@
         "databaseName": "FortiGateAutoscale",
         "databaseSharedThroughput": "[add(add(variables('databaseSharedThroughputBase'), if(variables('enableHybridLicensing'), 200, 0)), if(variables('enableFortiAnalyzer'), 100, 0))]",
         "databaseSharedThroughputBase": 500,
-        "enableFortiAnalyzer": true,
+        "enableFortiAnalyzer": "[equals(parameters('FortiAnalyzerIntegrationOptions'), 'yes')]",
         "enableHybridLicensing": true,
         "extLBFrontendIPConfigNameSubnet1": "external-lb-frontend-ip-config-subnet-1",
         "extLBFrontendPortRangeEndHTTPS": 40120,

--- a/templates/deploy_fortigate_autoscale.hybrid_licensing.json
+++ b/templates/deploy_fortigate_autoscale.hybrid_licensing.json
@@ -1524,7 +1524,7 @@
             "properties": {
                 "mode": "Incremental",
                 "templateLink": {
-                    "uri": "https://raw.githubusercontent.com/fortinet/fortigate-autoscale-azure/main/linked_template.faz_integration.json"
+                    "uri": "https://raw.githubusercontent.com/fortinet/fortigate-autoscale-azure/main/templates/linked_template.faz_integration.json"
                 },
                 "parameters": {
                     "AdminPassword": {
@@ -1567,7 +1567,7 @@
             "properties": {
                 "mode": "Incremental",
                 "templateLink": {
-                    "uri": "https://raw.githubusercontent.com/fortinet/fortigate-autoscale-azure/main/linked_template.function_app.json"
+                    "uri": "https://raw.githubusercontent.com/fortinet/fortigate-autoscale-azure/main/templates/linked_template.function_app.json"
                 },
                 "parameters": {
                     "FunctionAppName": {
@@ -1605,7 +1605,7 @@
             "properties": {
                 "mode": "Incremental",
                 "templateLink": {
-                    "uri": "https://raw.githubusercontent.com/fortinet/fortigate-autoscale-azure/main/linked_template.function_app.setup.json"
+                    "uri": "https://raw.githubusercontent.com/fortinet/fortigate-autoscale-azure/main/templates/linked_template.function_app.setup.json"
                 },
                 "parameters": {
                     "AdminPortNumber": {
@@ -1723,7 +1723,7 @@
             "properties": {
                 "mode": "Incremental",
                 "templateLink": {
-                    "uri": "https://raw.githubusercontent.com/fortinet/fortigate-autoscale-azure/main/linked_template.vmss.json"
+                    "uri": "https://raw.githubusercontent.com/fortinet/fortigate-autoscale-azure/main/templates/linked_template.vmss.json"
                 },
                 "parameters": {
                     "AdminPassword": {

--- a/templates/deploy_fortigate_autoscale.hybrid_licensing.json
+++ b/templates/deploy_fortigate_autoscale.hybrid_licensing.json
@@ -31,24 +31,28 @@
             }
         },
         "FortiAnalyzerAutoscaleAdminPassword": {
+            "defaultValue": "",
             "type": "securestring",
             "metadata": {
                 "description": "The password for the 'Autoscale admin username'. The password must conform to the FortiAnalyzer password policy and have a min length of 8 and a max length 128. If you need to enable KMS encryption, refer to the documentation."
             }
         },
         "FortiAnalyzerAutoscaleAdminUsername": {
+            "defaultValue": "",
             "type": "string",
             "metadata": {
                 "description": "This FortiAnalyzer account name can include numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen (-)."
             }
         },
         "FortiAnalyzerCustomPrivateIpAddress": {
+            "defaultValue": "",
             "type": "string",
             "metadata": {
                 "description": "The custom private IP address to be used by the FortiAnalyzer. Must be within the Public subnet 1 CIDR range. Required if 'FortiAnalyzer Integration' is set to 'yes'. If 'FortiAnalyzer Integration' is set to 'no', any input will be ignored."
             }
         },
         "FortiAnalyzerInstanceType": {
+            "defaultValue": "",
             "type": "String",
             "metadata": {
                 "description": "Size of the FortiAnalyzer VM."

--- a/templates/deploy_fortigate_autoscale.hybrid_licensing.json
+++ b/templates/deploy_fortigate_autoscale.hybrid_licensing.json
@@ -1524,7 +1524,7 @@
             "properties": {
                 "mode": "Incremental",
                 "templateLink": {
-                    "uri": "https://raw.githubusercontent.com/fortinet/fortigate-autoscale-azure/3.3.0-dev.0/templates/linked_template.faz_integration.json"
+                    "uri": "https://raw.githubusercontent.com/fortinet/fortigate-autoscale-azure/main/linked_template.faz_integration.json"
                 },
                 "parameters": {
                     "AdminPassword": {
@@ -1567,7 +1567,7 @@
             "properties": {
                 "mode": "Incremental",
                 "templateLink": {
-                    "uri": "https://raw.githubusercontent.com/fortinet/fortigate-autoscale-azure/3.3.0-dev.0/templates/linked_template.function_app.json"
+                    "uri": "https://raw.githubusercontent.com/fortinet/fortigate-autoscale-azure/main/linked_template.function_app.json"
                 },
                 "parameters": {
                     "FunctionAppName": {
@@ -1605,7 +1605,7 @@
             "properties": {
                 "mode": "Incremental",
                 "templateLink": {
-                    "uri": "https://raw.githubusercontent.com/fortinet/fortigate-autoscale-azure/3.3.0-dev.0/templates/linked_template.function_app.setup.json"
+                    "uri": "https://raw.githubusercontent.com/fortinet/fortigate-autoscale-azure/main/linked_template.function_app.setup.json"
                 },
                 "parameters": {
                     "AdminPortNumber": {
@@ -1723,7 +1723,7 @@
             "properties": {
                 "mode": "Incremental",
                 "templateLink": {
-                    "uri": "https://raw.githubusercontent.com/fortinet/fortigate-autoscale-azure/3.3.0-dev.0/templates/linked_template.vmss.json"
+                    "uri": "https://raw.githubusercontent.com/fortinet/fortigate-autoscale-azure/main/linked_template.vmss.json"
                 },
                 "parameters": {
                     "AdminPassword": {

--- a/templates/linked_template.function_app.setup.json
+++ b/templates/linked_template.function_app.setup.json
@@ -117,7 +117,7 @@
             "properties": {
                 "mode": "Incremental",
                 "templateLink": {
-                    "uri": "https://raw.githubusercontent.com/fortinet/fortigate-autoscale-azure/3.3.0-dev.0/templates/linked_template.function_app.update.json"
+                    "uri": "https://raw.githubusercontent.com/fortinet/fortigate-autoscale-azure/main/linked_template.function_app.update.json"
                 },
                 "parameters": {
                     "AdminPortNumber": {

--- a/templates/linked_template.function_app.setup.json
+++ b/templates/linked_template.function_app.setup.json
@@ -117,7 +117,7 @@
             "properties": {
                 "mode": "Incremental",
                 "templateLink": {
-                    "uri": "https://raw.githubusercontent.com/fortinet/fortigate-autoscale-azure/main/linked_template.function_app.update.json"
+                    "uri": "https://raw.githubusercontent.com/fortinet/fortigate-autoscale-azure/main/templates/linked_template.function_app.update.json"
                 },
                 "parameters": {
                     "AdminPortNumber": {

--- a/templates/linked_template.function_app.setup.json
+++ b/templates/linked_template.function_app.setup.json
@@ -106,7 +106,9 @@
             "type": "String"
         }
     },
-    "variables": {},
+    "variables": {
+        "enableFortiAnalyzer": "[equals(parameters('FortiAnalyzerIntegrationOptions'), 'yes')]"
+    },
     "resources": [
         {
             "type": "Microsoft.Resources/deployments",
@@ -149,7 +151,7 @@
                         "value": "[parameters('FunctionAppName')]"
                     },
                     "FunctionKeyFazAuthHandler": {
-                        "value": "[listKeys(resourceId(subscription().subscriptionId, parameters('FunctionAppResourceGroupName'), 'Microsoft.Web/sites/functions', parameters('FunctionAppName'),  parameters('FunctionNameFazAuthHandler')), '2019-08-01').default]"
+                        "value": "[if( variables('enableFortiAnalyzer'), listKeys(resourceId(subscription().subscriptionId, parameters('FunctionAppResourceGroupName'), 'Microsoft.Web/sites/functions', parameters('FunctionAppName'),  parameters('FunctionNameFazAuthHandler')), '2019-08-01').default,'')]"
                     },
                     "FunctionNameFazAuthHandler": {
                         "value": "[parameters('FunctionNameFazAuthHandler')]"


### PR DESCRIPTION
when deploying without faz, some link templates still try to reference the faz resource, which cause the deployment failure.