### PR TITLE
Bugfix missing auth token

### DIFF
--- a/templates/deploy_fortigate_autoscale.hybrid_licensing.json
+++ b/templates/deploy_fortigate_autoscale.hybrid_licensing.json
@@ -352,7 +352,7 @@
         "autoscaleAssetContainerName": "fortigate-autoscale",
         "cmdDeleteAutoscaleAll": "[concat('az account set -s ', subscription().subscriptionId, ';', variables('cmdDeleteVNetAll'), variables('cmdDeleteDatabaseAll'))]",
         "cmdDeleteDatabaseAll": "[concat('az account set -s ', subscription().subscriptionId, ';', variables('cmdDeleteDatabase'), variables('cmdDeleteDatabaseAccount'))]",
-        "cmdDeleteDatabase": "[concat('az cosmosdb database delete -y -g ', resourceGroup().name, ' -n ', variables('databaseName'), ';')]",
+        "cmdDeleteDatabase": "[concat('az cosmosdb sql database delete -y -g ', resourceGroup().name, ' -a ', variables('databaseAccountName'), ' -n ', variables('databaseName'), ';')]",
         "cmdDeleteDatabaseAccount": "[concat('az cosmosdb delete -y -g ', resourceGroup().name, ' -n ', variables('databaseAccountName'), ';')]",
         "cmdDeleteLBS": "[concat('az network lb delete -g ', variables('vNetResourceGroupName'),' -n ', variables('externalLoadBalancerName'), ';', 'az network lb delete -g ', variables('vNetResourceGroupName'),' -n ', variables('internalLoadBalancerName'), ';')]",
         "cmdDeleteNetworkSecurityGroup": "[if(variables('ifCreateVNet'), concat('az network nsg delete -g ', variables('vNetResourceGroupName'),' -n ', variables('networkSecurityGroupName'), ';'), '')]",

--- a/templates/linked_template.function_app.json
+++ b/templates/linked_template.function_app.json
@@ -27,9 +27,9 @@
     },
     "variables": {
         "cmdDeleteAll": "[concat('az account set -s ', subscription().subscriptionId, ';', variables('cmdDeleteInsights'), variables('cmdDeleteSite'), variables('cmdDeleteServerFarm'))]",
-        "cmdDeleteInsights": "[if(variables('enableAzureAppInsights'), concat('az monitor app-insights component delete', ' -a ', parameters('FunctionAppName'), ' -g ', resourceGroup().name, ';'), '')]",
+        "cmdDeleteInsights": "[if(variables('enableAzureAppInsights'), concat('az monitor app-insights component delete', ' -a ', variables('functionAppInsightName'), ' -g ', resourceGroup().name, ';'), '')]",
         "cmdDeleteServerFarm": "[concat('az appservice plan delete -y', ' -n ', variables('hostingPlanName'), ' -g ', resourceGroup().name, ';')]",
-        "cmdDeleteSite": "[concat('az webapp delete -y', ' -n ', parameters('FunctionAppName'), ' -g ', resourceGroup().name, ';')]",
+        "cmdDeleteSite": "[concat('az webapp delete', ' -n ', parameters('FunctionAppName'), ' -g ', resourceGroup().name, ';')]",
         "enableAzureAppInsights": "[contains(variables('functionAppInsightAvailableLocations'), resourceGroup().location)]",
         "functionAppInsightAvailableLocations": [
             "australiaeast",

--- a/templates/linked_template.function_app.setup.json
+++ b/templates/linked_template.function_app.setup.json
@@ -156,6 +156,9 @@
                     "FunctionNameFazAuthHandler": {
                         "value": "[parameters('FunctionNameFazAuthHandler')]"
                     },
+                    "FunctionKeyFgtAsHandler": {
+                        "value": "[listKeys(resourceId(subscription().subscriptionId, parameters('FunctionAppResourceGroupName'), 'Microsoft.Web/sites/functions', parameters('FunctionAppName'),  parameters('FunctionNameFgtAsHandler')), '2019-08-01').default]"
+                    },
                     "FunctionNameFgtAsHandler": {
                         "value": "[parameters('FunctionNameFgtAsHandler')]"
                     },

--- a/templates/linked_template.function_app.update.json
+++ b/templates/linked_template.function_app.update.json
@@ -39,6 +39,9 @@
         "FunctionNameFazAuthHandler": {
             "type": "String"
         },
+        "FunctionKeyFgtAsHandler": {
+            "type": "securestring"
+        },
         "FunctionNameFgtAsHandler": {
             "type": "String"
         },
@@ -244,7 +247,7 @@
                         },
                         {
                             "name": "autoscale-handler-url",
-                            "value": "[concat(variables('funcappURL'), '/api/', parameters('FunctionNameFgtAsHandler'))]"
+                            "value": "[concat(variables('funcappURL'), '/api/', parameters('FunctionNameFgtAsHandler'),  '?code=', parameters('FunctionKeyFgtAsHandler'))]"
                         },
                         {
                             "name": "byol-scaling-group-desired-capacity",


### PR DESCRIPTION
Function access key is missing in the autoscale-handler function url. This causes the FortiGate vm heartbeats callbakc unable to reach to the Autoscale handler function.

The primary election will fail.

Should bump the version on patch level


fix #31 