### PR TITLE
enable the custom asset container and directory by default

### DIFF
--- a/templates/link_template.function_app.configuration.json
+++ b/templates/link_template.function_app.configuration.json
@@ -267,11 +267,11 @@
                         },
                         {
                             "name": "custom-asset-container",
-                            "value": "n/a"
+                            "value": "fortigate-autoscale"
                         },
                         {
                             "name": "custom-asset-directory",
-                            "value": "n/a"
+                            "value": "custom-assets"
                         },
                         {
                             "name": "egress-traffic-route-table",


### PR DESCRIPTION
enable the custom assets location by the initial deployment: forigate-autoscale/custom-assets

the behaviour changes related to Autoscale is in loading configset files:
1. if the forigate-autoscale/custom-assets directory doesn't exist, or the directory doesn't contain any file, nothing will change.
2. if the forigate-autoscale/custom-assets exists and it contains files, the files will be loaded as additional custom configsets.

Since the storage account is deployed as private. Users must obtain sufficient permissions to be able to manually manage this directory and files. Therefore, this change will not impose any security risk to the Autoscale stack.

For QA, it requires the following tests:
1. upload 2 configset files to the location: fortigate-autoscale/custom-assets/configset, then verify if the content of these two configset files is loaded into the bootstrap configuration. This test is to ensure ANY configset file in such location will be loaded automatically. Notes: each of the 2 files must contain valid and complete FOS commands.