### PR TITLE
patch proj 15397 use core 3.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@azure/functions": "^1.2.3",
-        "@fortinet/fortigate-autoscale": "https://github.com/fortinet/autoscale-core/releases/download/3.3.1-dev.0/fortinet-fortigate-autoscale-3.3.1-dev.0.tgz",
+        "@fortinet/fortigate-autoscale": "https://github.com/fortinet/autoscale-core/releases/download/3.3.1/fortinet-fortigate-autoscale-3.3.1.tgz",
         "@types/node": "^13.13.50",
         "http-status-codes": "^1.4.0"
       },
@@ -644,9 +644,9 @@
       }
     },
     "node_modules/@fortinet/fortigate-autoscale": {
-      "version": "3.3.1-dev.0",
-      "resolved": "https://github.com/fortinet/autoscale-core/releases/download/3.3.1-dev.0/fortinet-fortigate-autoscale-3.3.1-dev.0.tgz",
-      "integrity": "sha512-x3nbpbEHUnN8UQ/7NfDzhv+n5ESuUw6/0N2aZikzuJflYk6GdKKYcEkq0cmf3wuvJ8syfc0ataNMmEoLmbiQ9Q==",
+      "version": "3.3.1",
+      "resolved": "https://github.com/fortinet/autoscale-core/releases/download/3.3.1/fortinet-fortigate-autoscale-3.3.1.tgz",
+      "integrity": "sha512-yihVVrIdhYl/ftvWSkgmrafCB9ZfkPeIO/XaUqJKxvGr1uKWrCddDLfHfau275SW9Zb8Yv6iv7118mJTOwRPIQ==",
       "bundleDependencies": [
         "@fortinet/autoscale-core"
       ],
@@ -666,7 +666,7 @@
       }
     },
     "node_modules/@fortinet/fortigate-autoscale/node_modules/@fortinet/autoscale-core": {
-      "version": "3.3.0",
+      "version": "3.3.1",
       "extraneous": true,
       "inBundle": true,
       "license": "MIT"
@@ -8721,8 +8721,8 @@
       "dev": true
     },
     "@fortinet/fortigate-autoscale": {
-      "version": "https://github.com/fortinet/autoscale-core/releases/download/3.3.1-dev.0/fortinet-fortigate-autoscale-3.3.1-dev.0.tgz",
-      "integrity": "sha512-x3nbpbEHUnN8UQ/7NfDzhv+n5ESuUw6/0N2aZikzuJflYk6GdKKYcEkq0cmf3wuvJ8syfc0ataNMmEoLmbiQ9Q==",
+      "version": "https://github.com/fortinet/autoscale-core/releases/download/3.3.1/fortinet-fortigate-autoscale-3.3.1.tgz",
+      "integrity": "sha512-yihVVrIdhYl/ftvWSkgmrafCB9ZfkPeIO/XaUqJKxvGr1uKWrCddDLfHfau275SW9Zb8Yv6iv7118mJTOwRPIQ==",
       "requires": {
         "@azure/arm-compute": "^15.0.0",
         "@azure/arm-network": "^23.2.0",
@@ -8738,7 +8738,7 @@
       },
       "dependencies": {
         "@fortinet/autoscale-core": {
-          "version": "3.3.0",
+          "version": "3.3.1",
           "bundled": true,
           "extraneous": true
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@azure/functions": "^1.2.3",
-        "@fortinet/fortigate-autoscale": "https://github.com/fortinet/autoscale-core/releases/download/3.2.8/fortinet-fortigate-autoscale-3.2.8.tgz",
+        "@fortinet/fortigate-autoscale": "https://github.com/fortinet/autoscale-core/releases/download/3.3.1-dev.0/fortinet-fortigate-autoscale-3.3.1-dev.0.tgz",
         "@types/node": "^13.13.50",
         "http-status-codes": "^1.4.0"
       },
@@ -644,9 +644,9 @@
       }
     },
     "node_modules/@fortinet/fortigate-autoscale": {
-      "version": "3.2.8",
-      "resolved": "https://github.com/fortinet/autoscale-core/releases/download/3.2.8/fortinet-fortigate-autoscale-3.2.8.tgz",
-      "integrity": "sha512-P+OFgHAPuJ1EoNACY0iQFQ8h8NgfndponB1075pJihibwcoxs3dfed3sslENVXsLE/hQPAS5ABfZ979GD9t8Gw==",
+      "version": "3.3.1-dev.0",
+      "resolved": "https://github.com/fortinet/autoscale-core/releases/download/3.3.1-dev.0/fortinet-fortigate-autoscale-3.3.1-dev.0.tgz",
+      "integrity": "sha512-x3nbpbEHUnN8UQ/7NfDzhv+n5ESuUw6/0N2aZikzuJflYk6GdKKYcEkq0cmf3wuvJ8syfc0ataNMmEoLmbiQ9Q==",
       "bundleDependencies": [
         "@fortinet/autoscale-core"
       ],
@@ -659,14 +659,15 @@
         "@azure/identity": "^1.2.2",
         "@azure/keyvault-secrets": "^4.1.0",
         "@azure/ms-rest-js": "^2.2.1",
-        "@azure/ms-rest-nodeauth": "^3.0.6",
+        "@azure/ms-rest-nodeauth": "^3.0.10",
         "@azure/storage-blob": "^12.4.1",
         "axios": "^0.21.1",
         "express": "^4.17.1"
       }
     },
     "node_modules/@fortinet/fortigate-autoscale/node_modules/@fortinet/autoscale-core": {
-      "version": "3.2.8",
+      "version": "3.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -8720,8 +8721,8 @@
       "dev": true
     },
     "@fortinet/fortigate-autoscale": {
-      "version": "https://github.com/fortinet/autoscale-core/releases/download/3.2.8/fortinet-fortigate-autoscale-3.2.8.tgz",
-      "integrity": "sha512-P+OFgHAPuJ1EoNACY0iQFQ8h8NgfndponB1075pJihibwcoxs3dfed3sslENVXsLE/hQPAS5ABfZ979GD9t8Gw==",
+      "version": "https://github.com/fortinet/autoscale-core/releases/download/3.3.1-dev.0/fortinet-fortigate-autoscale-3.3.1-dev.0.tgz",
+      "integrity": "sha512-x3nbpbEHUnN8UQ/7NfDzhv+n5ESuUw6/0N2aZikzuJflYk6GdKKYcEkq0cmf3wuvJ8syfc0ataNMmEoLmbiQ9Q==",
       "requires": {
         "@azure/arm-compute": "^15.0.0",
         "@azure/arm-network": "^23.2.0",
@@ -8730,15 +8731,16 @@
         "@azure/identity": "^1.2.2",
         "@azure/keyvault-secrets": "^4.1.0",
         "@azure/ms-rest-js": "^2.2.1",
-        "@azure/ms-rest-nodeauth": "^3.0.6",
+        "@azure/ms-rest-nodeauth": "^3.0.10",
         "@azure/storage-blob": "^12.4.1",
         "axios": "^0.21.1",
         "express": "^4.17.1"
       },
       "dependencies": {
         "@fortinet/autoscale-core": {
-          "version": "3.2.8",
-          "bundled": true
+          "version": "3.3.0",
+          "bundled": true,
+          "extraneous": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "homepage": "https://github.com/fortinet/fortigate-autoscale-azure#readme",
   "dependencies": {
     "@azure/functions": "^1.2.3",
-    "@fortinet/fortigate-autoscale": "https://github.com/fortinet/autoscale-core/releases/download/3.3.1-dev.0/fortinet-fortigate-autoscale-3.3.1-dev.0.tgz",
+    "@fortinet/fortigate-autoscale": "https://github.com/fortinet/autoscale-core/releases/download/3.3.1/fortinet-fortigate-autoscale-3.3.1.tgz",
     "@types/node": "^13.13.50",
     "http-status-codes": "^1.4.0"
   },

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "homepage": "https://github.com/fortinet/fortigate-autoscale-azure#readme",
   "dependencies": {
     "@azure/functions": "^1.2.3",
-    "@fortinet/fortigate-autoscale": "https://github.com/fortinet/autoscale-core/releases/download/3.2.8/fortinet-fortigate-autoscale-3.2.8.tgz",
+    "@fortinet/fortigate-autoscale": "https://github.com/fortinet/autoscale-core/releases/download/3.3.1-dev.0/fortinet-fortigate-autoscale-3.3.1-dev.0.tgz",
     "@types/node": "^13.13.50",
     "http-status-codes": "^1.4.0"
   },

--- a/templates/deploy_fortigate_autoscale.hybrid_licensing.json
+++ b/templates/deploy_fortigate_autoscale.hybrid_licensing.json
@@ -88,8 +88,8 @@
             }
         },
         "FOSVersion": {
-            "defaultValue": "6.4.5",
-            "allowedValues": ["6.4.5"],
+            "defaultValue": "7.0.1",
+            "allowedValues": ["7.0.1", "7.0.0", "6.4.7", "6.4.5"],
             "type": "String",
             "metadata": {
                 "description": "FortiOS version supported by FortiGate Autoscale for Azure."


### PR DESCRIPTION
use the autoscale-core@3.3.1 for FOS7.0.1 primary/secondary terminology change.
And update template to add support for FOS 7.0.1/7.0.0/6.4.7