### PR TITLE
Update link_template.function_app.json

### DIFF
--- a/templates/link_template.function_app.json
+++ b/templates/link_template.function_app.json
@@ -145,7 +145,7 @@
                         },
                         {
                             "name": "[if(variables('enableAzureAppInsights'), 'APPINSIGHTS_INSTRUMENTATIONKEY', 'DEPLOYED_APPINSIGHTS')]",
-                            "value": "[if(variables('enableAzureAppInsights'), reference(resourceId('Microsoft.Insights/components/', variables('appInsightName')), '2018-05-01-preview').InstrumentationKey, 'false')]"
+                            "value": "[if(variables('enableAzureAppInsights'), reference(resourceId('Microsoft.Insights/components/', variables('appInsightName')), '2020-02-02').InstrumentationKey, 'false')]"
                         },
                         {
                             "name": "FUNCTIONS_EXTENSION_VERSION",
@@ -178,12 +178,13 @@
         },
         {
             "type": "Microsoft.Insights/components",
-            "apiVersion": "2018-05-01-preview",
+            "apiVersion": "2020-02-02",
             "name": "[variables('appInsightName')]",
             "location": "[resourceGroup().location]",
             "kind": "web",
             "properties": {
                 "Application_Type": "web",
+				"IngestionMode": "LogAnalytics",
                 "ApplicationId": "[parameters('FunctionAppName')]"
             },
             "condition": "[variables('enableAzureAppInsights')]"


### PR DESCRIPTION
Updating Azure Application Insights deployment to allow deployment to regions that do not allow a "Classic" resource mode, and only allow "Workspace-based" resource mode (e.g.: Canada East). Classic mode is set to be retired in February 2024.