### PR TITLE
Remove spot instance for PAYG

### DIFF
--- a/templates/deploy_fortigate_autoscale.hybrid_licensing.json
+++ b/templates/deploy_fortigate_autoscale.hybrid_licensing.json
@@ -88,8 +88,12 @@
             }
         },
         "FOSVersion": {
-            "defaultValue": "7.2.2",
-            "allowedValues": ["7.2.2"],
+            "defaultValue": "7.2.5",
+            "allowedValues": [
+                "7.2.5",
+                "7.4.0",
+                "latest"
+            ],
             "type": "String",
             "metadata": {
                 "description": "FortiOS version supported by FortiGate Autoscale for Azure."

--- a/templates/deploy_fortigate_autoscale.hybrid_licensing.params.json
+++ b/templates/deploy_fortigate_autoscale.hybrid_licensing.params.json
@@ -33,7 +33,7 @@
             "value": ""
         },
         "FOSVersion": {
-            "value": "7.2.2"
+            "value": "7.2.3"
         },
         "HeartBeatDelayAllowance": {
             "value": 30

--- a/templates/link_template.vmss.json
+++ b/templates/link_template.vmss.json
@@ -471,8 +471,6 @@
                             "storageUri": "[concat('https://', parameters('StorageAccountName'), '.blob.core.windows.net')]"
                         }
                     },
-                    "priority": "Low",
-                    "evictionPolicy": "delete",
                     "osProfile": {
                         "computerNamePrefix": "[parameters('VmssNamePAYG')]",
                         "customData": "[base64(concat('{\"config-url\": \"', 'https://', parameters('FunctionAppName'), '.azurewebsites.net/api/', parameters('FunctionNameFgtAsHandler'), '?code=', listKeys(resourceId(subscription().subscriptionId, parameters('FunctionAppResourceGroupName'), 'Microsoft.Web/sites/functions', parameters('FunctionAppName'),  'fgt-as-handler'), '2019-08-01').default, '\"}\n'))]",


### PR DESCRIPTION
By default, spot instances are enable in the autoscale template for the PAYG VMSS deployment. Spot instances have become more difficult to get a hold of recently and are not optimal for a statefull firewall. They can be evicted at any time resulting in dead connections.

https://azure.microsoft.com/en-us/products/virtual-machines/spot/
