### PR TITLE
Enabled IP Forwarding on internal NIC

### DIFF
--- a/templates/link_template.vmss.json
+++ b/templates/link_template.vmss.json
@@ -320,7 +320,7 @@
                         "name": "[concat('nic-config-subnet', add(copyIndex('networkInterfaceConfigurationNonLoadBalancingSubnetsCopyIt'), 1))]",
                         "properties": {
                             "primary": false,
-                            "enableIPForwarding": false,
+                            "enableIPForwarding": true,
                             "ipConfigurations": [
                                 {
                                     "name": "[concat('ip-config-subnet', add(copyIndex('networkInterfaceConfigurationNonLoadBalancingSubnetsCopyIt'), 1))]",


### PR DESCRIPTION
For the FortiGate to forward outbound traffic requires IP Forwarding to be enabled on the internal side for return packets.