### PR TITLE
Azure Function: Add httpsOnly tag to disable http

### DIFF
--- a/templates/link_template.function_app.configuration.json
+++ b/templates/link_template.function_app.configuration.json
@@ -134,6 +134,7 @@
             "location": "[resourceGroup().location]",
             "kind": "functionapp",
             "properties": {
+                "httpsOnly": true,
                 "siteConfig": {
                     "appSettings": [
                         {

--- a/templates/link_template.function_app.json
+++ b/templates/link_template.function_app.json
@@ -173,7 +173,8 @@
                         }
                     ]
                 },
-                "alwaysOn": true
+                "alwaysOn": true,
+                "httpsOnly": true
             }
         },
         {


### PR DESCRIPTION
Forces Azure Function to only use HTTPS as customers might have a policy preventing the use of HTTP.