### PR TITLE
Prevent PAYG VMSS to be deployed when selecting on BYOL

### DIFF
--- a/templates/link_template.vmss.json
+++ b/templates/link_template.vmss.json
@@ -356,7 +356,6 @@
             }
         },
         "networkInterfaceConfigurationSubnet1PAYG": {
-            "condition": "[not(variables('ifBYOLOnly'))]",
             "name": "nic-config-subnet1",
             "properties": {
                 "primary": true,

--- a/templates/link_template.vmss.json
+++ b/templates/link_template.vmss.json
@@ -356,6 +356,7 @@
             }
         },
         "networkInterfaceConfigurationSubnet1PAYG": {
+            "condition": "[not(variables('ifBYOLOnly'))]",
             "name": "nic-config-subnet1",
             "properties": {
                 "primary": true,
@@ -435,6 +436,7 @@
             "zones": "[parameters('AvailabilityZones')]"
         },
         {
+            "condition": "[not(variables('ifBYOLOnly'))]",
             "type": "Microsoft.Compute/virtualMachineScaleSets",
             "apiVersion": "2019-07-01",
             "name": "[parameters('VmssNamePAYG')]",
@@ -514,6 +516,7 @@
             }
         },
         {
+            "condition": "[not(variables('ifBYOLOnly'))]",
             "type": "Microsoft.Insights/autoscaleSettings",
             "apiVersion": "2014-04-01",
             "name": "[variables('autoscaleSettingsNamePAYG')]",


### PR DESCRIPTION
Customer only allows BYOL as such no PAYG VMSS should be deployed. ifBYOLOnly flag should reflect this.
If customer wants to have no PAYG instances they can deploy and set instance count to 0.